### PR TITLE
Fix critical auth security holes, harden for online deploy, start multi-tenant registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/vendor/
+.phpunit.result.cache
+/config/env.php
+/data/registry.db
+/data/*.db
+!/data/ung_dung.db

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,13 @@
+# Docroot Apache = gốc repo (JS gọi API bằng đường dẫn tương đối ../api/...).
+# Mặc định CHẶN truy cập trực tiếp mọi thứ ở đây (config/, lib/, data/, tests/,
+# scripts/, tools/, vendor/, composer.*, phpunit.xml, phpstan.neon.dist...).
+# public/, api/, upload/ có .htaccess riêng để tự mở lại quyền truy cập.
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Deny from all
+</IfModule>

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -21,6 +21,14 @@
   - Workflow deploy FTP giữ nguyên ( `.github/workflows/deploy.yml` ).
 
 - **Chạy ứng dụng**
-  - Dev nhanh: `php -S 0.0.0.0:8000 -t public`
-  - Sản xuất: trỏ vhost vào `public/`, bật HTTPS, cấp quyền ghi cho `data/` và `upload/`.
+  - Dev nhanh: `php -S 0.0.0.0:8000` chạy tại **thư mục gốc repo** (không `-t public` — xem lý do trong README.md), truy cập `http://localhost:8000/public/...`.
+  - Sản xuất: DocumentRoot của vhost trỏ vào **gốc repo** (không phải `public/`), vì JS gọi API qua đường dẫn tương đối `../api/...` cần `public/` và `api/` là 2 thư mục anh em. Vì docroot là gốc repo, **bắt buộc** phải chặn truy cập trực tiếp các thư mục/file nhạy cảm (`config/`, `lib/`, `data/`, `tests/`, `scripts/`, `tools/`, `vendor/`, `composer.json`, `composer.lock`, `phpunit.xml`, `phpstan.neon.dist`) — repo đã có sẵn `.htaccess` gốc chặn mặc định (deny-by-default) và `.htaccess` riêng trong `public/`, `api/`, `upload/` để mở lại quyền truy cập cho 3 thư mục này. Chỉ hoạt động nếu Apache bật `AllowOverride All` (hoặc tối thiểu `AllowOverride Limit AuthConfig`) cho vhost.
+
+- **Checklist bảo mật trước khi deploy online (Apache)**
+  - `AllowOverride All` (hoặc tương đương) phải bật cho vhost để các file `.htaccess` trong repo có hiệu lực — nếu không, `config/`, `data/`... sẽ lộ trực tiếp qua URL.
+  - Tắt `display_errors`, bật `log_errors` trong `php.ini` production (không để lộ stack trace/đường dẫn server khi có lỗi).
+  - Bắt buộc HTTPS: dùng Let's Encrypt/mod_ssl trực tiếp trên Apache, hoặc đặt sau reverse proxy (Nginx/Cloudflare) có TLS termination — code đã tự nhận diện HTTPS qua `X-Forwarded-Proto` khi chạy sau proxy (xem `dang_https()` trong `config/db.php`).
+  - Đổi mật khẩu tài khoản `gv1` mặc định ngay sau lần đăng nhập đầu (hệ thống đã bắt buộc việc này, không cho dùng API/trang khác cho tới khi đổi).
+  - Sinh `remember_secret` ngẫu nhiên trong `config/env.php` (`php -r "echo bin2hex(random_bytes(32));"`) trước khi bật tính năng "ghi nhớ đăng nhập".
+  - Cấp quyền ghi cho `data/` và `upload/` (user chạy PHP-FPM/mod_php), nhưng đảm bảo cả 2 không lộ qua URL ngoài các file ảnh hợp lệ trong `upload/`.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Cài đặt nhanh
 1) Yêu cầu: PHP 8+ với PDO SQLite.
 2) Clone dự án, đảm bảo PHP có quyền ghi `data/` và `upload/`.
-3) Chạy `php -S 0.0.0.0:8000 -t public` (hoặc dùng web server khác), truy cập `public/dang_nhap.php` để khởi tạo DB:
+3) Chạy `php -S 0.0.0.0:8000` tại **thư mục gốc repo** (không dùng `-t public` vì JS trong `public/*.php` gọi API bằng đường dẫn tương đối `../api/...`, cần `public/` và `api/` là 2 thư mục anh em cùng cấp docroot), truy cập `http://localhost:8000/public/dang_nhap.php` để khởi tạo DB:
    - Tài khoản seed: `gv1` / `123456` (vai trò `ADMIN`). Đổi mật khẩu ngay sau khi đăng nhập.
 
 ## Cấu trúc thư mục

--- a/api/.htaccess
+++ b/api/.htaccess
@@ -1,0 +1,10 @@
+# Mở lại quyền truy cập cho api/ (bị chặn mặc định bởi .htaccess ở gốc repo).
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>

--- a/api/dang_nhap.php
+++ b/api/dang_nhap.php
@@ -36,8 +36,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $hanh_dong === 'dang_nhap') {
   
   $gv = kiem_tra_dang_nhap($pdo, $ten, $mk);
   if ($gv) {
-    // Đăng nhập thành công
+    // Đăng nhập thành công: đổi session ID để chống session fixation, giữ nguyên dữ liệu session hiện có
+    session_regenerate_id(true);
     $_SESSION['giao_vien_id'] = (int)$gv['id']; $_SESSION['ten_dang_nhap'] = $gv['ten_dang_nhap']; $_SESSION['vai_tro'] = $gv['vai_tro'] ?? 'GV';
+    $_SESSION['phai_doi_mat_khau'] = (bool)((int)($gv['phai_doi_mat_khau'] ?? 0));
     // Reset đếm sai và CAPTCHA
     if (isset($_SESSION['dn_sai'][$k])) unset($_SESSION['dn_sai'][$k]);
     xoa_captcha();

--- a/api/giao_vien_quan_tri.php
+++ b/api/giao_vien_quan_tri.php
@@ -43,7 +43,8 @@ if ($hanh_dong === 'doi_mat_khau') {
   $gv = $st->fetch();
   if (!$gv || !password_verify($mk_cu, $gv['mat_khau_bam'])) json_phan_hoi(false, null, 'mat_khau_cu_khong_dung');
   $bam = password_hash($mk_moi, PASSWORD_DEFAULT);
-  $pdo->prepare('UPDATE giao_vien SET mat_khau_bam=? WHERE id=?')->execute([$bam, (int)$gv['id']]);
+  $pdo->prepare('UPDATE giao_vien SET mat_khau_bam=?, phai_doi_mat_khau=0 WHERE id=?')->execute([$bam, (int)$gv['id']]);
+  $_SESSION['phai_doi_mat_khau'] = false;
   ghi_log($pdo, (int)$_SESSION['giao_vien_id'], 'doi_mat_khau', 'Đổi mật khẩu tài khoản '.$_SESSION['ten_dang_nhap']);
   json_phan_hoi(true);
 }
@@ -80,6 +81,7 @@ if ($hanh_dong === 'them') {
 }
 
 if ($hanh_dong === 'cap_nhat_lop') {
+  if (!$is_admin) json_phan_hoi(false, null, 'khong_du_quyen');
   $gvId = isset($b['giao_vien_id']) ? (int)$b['giao_vien_id'] : (int)$_SESSION['giao_vien_id'];
   if ($gvId <= 0) json_phan_hoi(false, null, 'thieu_giao_vien_id');
   // Kiểm tra giáo viên tồn tại

--- a/api/hoc_sinh.php
+++ b/api/hoc_sinh.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 require __DIR__ . '/../config/db.php';
 require __DIR__ . '/../lib/tro_giup.php';
+require __DIR__ . '/../lib/diem_nghiep_vu.php';
 /** @var \PDO $pdo Global PDO instance from config/db.php */
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
@@ -62,10 +63,21 @@ if ($method === 'POST' && $hanh_dong === 'sua') {
   $b = than_json();
   $id = (int)($b['id'] ?? 0);
   if ($id <= 0) json_phan_hoi(false, null, 'thieu_id');
+  $la_admin = (($_SESSION['vai_tro'] ?? '') === 'ADMIN');
+  try { kiem_tra_quyen_lop($pdo, $la_admin, (int)$_SESSION['giao_vien_id'], $id); }
+  catch (Throwable $e) { json_phan_hoi(false, null, 'khong_du_quyen'); }
   $set = [];$pr=[];
   if (array_key_exists('ma',$b)) { $set[]='ma=?'; $pr[] = (trim((string)$b['ma']) ?: null); }
   if (array_key_exists('ho_ten',$b)) { $ht=trim((string)$b['ho_ten']); if ($ht==='') json_phan_hoi(false, null, 'thieu_ho_ten'); $set[]='ho_ten=?'; $pr[] = $ht; }
-  if (array_key_exists('lop_hoc_id',$b)) { $lv = $b['lop_hoc_id']; $set[]='lop_hoc_id=?'; $pr[] = ($lv===null || $lv==='' ? null : (int)$lv); }
+  if (array_key_exists('lop_hoc_id',$b)) {
+    $lv = $b['lop_hoc_id'];
+    $lop_moi = ($lv===null || $lv==='' ? null : (int)$lv);
+    if (!$la_admin && $lop_moi !== null) {
+      $lop_gan = lop_duoc_gan($pdo, $la_admin, (int)$_SESSION['giao_vien_id']);
+      if ($lop_gan && !in_array($lop_moi, $lop_gan, true)) json_phan_hoi(false, null, 'khong_du_quyen');
+    }
+    $set[]='lop_hoc_id=?'; $pr[] = $lop_moi;
+  }
   if (array_key_exists('anh_dai_dien_url',$b)) { $set[]='anh_dai_dien_url=?'; $pr[] = (trim((string)$b['anh_dai_dien_url']) ?: null); }
   if (array_key_exists('gioi_tinh',$b)) { $set[]='gioi_tinh=?'; $pr[] = (trim((string)$b['gioi_tinh']) ?: null); }
   if (array_key_exists('ngay_sinh',$b)) { $set[]='ngay_sinh=?'; $pr[] = (trim((string)$b['ngay_sinh']) ?: null); }
@@ -83,6 +95,9 @@ if ($method === 'POST' && $hanh_dong === 'bat_tat') {
   $id = (int)($b['id'] ?? 0);
   $trang_thai = (int)($b['dang_hoat_dong'] ?? 1) ? 1 : 0;
   if ($id <= 0) json_phan_hoi(false, null, 'thieu_id');
+  $la_admin = (($_SESSION['vai_tro'] ?? '') === 'ADMIN');
+  try { kiem_tra_quyen_lop($pdo, $la_admin, (int)$_SESSION['giao_vien_id'], $id); }
+  catch (Throwable $e) { json_phan_hoi(false, null, 'khong_du_quyen'); }
   $pdo->prepare('UPDATE hoc_sinh SET dang_hoat_dong=? WHERE id=?')->execute([$trang_thai, $id]);
   json_phan_hoi(true);
 }

--- a/api/lop_hoc_quan_tri.php
+++ b/api/lop_hoc_quan_tri.php
@@ -5,6 +5,7 @@ require __DIR__ . '/../lib/tro_giup.php';
 /** @var \PDO $pdo Global PDO instance from config/db.php */
 
 yeu_cau_dang_nhap();
+$is_admin = (($_SESSION['vai_tro'] ?? '') === 'ADMIN');
 
 // Đảm bảo có cột dang_hoat_dong (migrate nhẹ nếu thiếu)
 try {
@@ -45,6 +46,7 @@ if ($method === 'GET') {
 }
 
 if ($method === 'POST') {
+  if (!$is_admin) json_phan_hoi(false, null, 'khong_du_quyen');
   $hanh_dong = $_GET['hanh_dong'] ?? '';
   $b = than_json();
   if ($hanh_dong === 'them') {

--- a/config/db.php
+++ b/config/db.php
@@ -5,10 +5,38 @@ $env_file = __DIR__ . '/env.php';
 if (file_exists($env_file)) {
   $env = require $env_file;
 }
+// Nhận diện HTTPS kể cả khi chạy sau reverse proxy/load balancer (Nginx, Cloudflare...)
+// chỉ tin header X-Forwarded-Proto nếu người vận hành cấu hình proxy đặt header này đúng cách.
+if (!function_exists('dang_https')) {
+  function dang_https(): bool {
+    if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') return true;
+    return ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https';
+  }
+}
 if (!headers_sent() && isset($env['session_name']) && is_string($env['session_name'])) {
   session_name($env['session_name']);
 }
+if (!headers_sent() && session_status() !== PHP_SESSION_ACTIVE) {
+  session_set_cookie_params([
+    'lifetime' => 0,
+    'path' => '/',
+    'secure' => dang_https(),
+    'httponly' => true,
+    'samesite' => 'Lax',
+  ]);
+}
 session_start();
+if (!headers_sent()) {
+  header('X-Content-Type-Options: nosniff');
+  header('X-Frame-Options: DENY');
+  header('Referrer-Policy: strict-origin-when-cross-origin');
+  // CSP nới lỏng cho inline script/style hiện có trong các trang public/*.php (chưa dùng nonce),
+  // nhưng vẫn chặn tải tài nguyên từ nguồn ngoài vì toàn bộ asset đã local hoá theo README.
+  header("Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-ancestors 'none'");
+  if (dang_https()) {
+    header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+  }
+}
 $DB_PATH = $env['db_path'] ?? (__DIR__ . '/../data/ung_dung.db');
 $DB_DIR = dirname($DB_PATH);
 $lan_dau = !file_exists($DB_PATH);
@@ -23,64 +51,13 @@ try {
   $pdo->exec("PRAGMA foreign_keys = ON");
 } catch (Exception $e) { http_response_code(500); echo 'Loi ket noi CSDL'; exit; }
 
-function chay_migration(PDO $pdo): void {
-  // Chuẩn hóa mã loại lịch sử cũ
-  try {
-    $pdo->exec("UPDATE so_cai_diem SET loai='CONG_DIEM' WHERE loai='CONG'");
-    $pdo->exec("UPDATE so_cai_diem SET loai='DOI_DIEM' WHERE loai='QUY_DOI'");
-  } catch (Throwable $e) { /* bảng có thể chưa tồn tại */ }
-  // Đảm bảo cột trong bảng
-  $ensureCols = function(string $table, array $cols) use ($pdo) {
-    try {
-      $info = $pdo->query("PRAGMA table_info($table)")->fetchAll();
-      $exist = array_map(fn($c) => $c['name'] ?? '', $info);
-      foreach ($cols as $col => $ddl) {
-        if (!in_array($col, $exist, true)) { $pdo->exec("ALTER TABLE $table ADD COLUMN $ddl"); }
-      }
-    } catch (Throwable $e) { /* ignore */ }
-  };
-  $ensureCols('hoc_sinh', [
-    'stt' => 'stt INTEGER',
-    'gioi_tinh' => 'gioi_tinh TEXT',
-    'ngay_sinh' => 'ngay_sinh TEXT',
-    'anh_dai_dien_url' => 'anh_dai_dien_url TEXT'
-  ]);
-  $ensureCols('giao_vien', [
-    'vai_tro' => "vai_tro TEXT DEFAULT 'GV'"
-  ]);
-  $ensureCols('qua_tang', [
-    'anh_url' => 'anh_url TEXT'
-  ]);
-  // Đảm bảo bảng tồn tại
-  try {
-    $pdo->exec("CREATE TABLE IF NOT EXISTS giao_vien_lop (
-      giao_vien_id INTEGER NOT NULL,
-      lop_hoc_id INTEGER NOT NULL,
-      PRIMARY KEY (giao_vien_id, lop_hoc_id),
-      FOREIGN KEY (giao_vien_id) REFERENCES giao_vien(id) ON DELETE CASCADE,
-      FOREIGN KEY (lop_hoc_id) REFERENCES lop_hoc(id) ON DELETE CASCADE
-    )");
-  } catch (Throwable $e) { /* ignore */ }
-  try {
-    $pdo->exec("CREATE TABLE IF NOT EXISTS reset_khoa (ten_dang_nhap TEXT PRIMARY KEY, het_han INTEGER)");
-  } catch (Throwable $e) { /* ignore */ }
-  try {
-    $pdo->exec("CREATE TABLE IF NOT EXISTS nhat_ky (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      giao_vien_id INTEGER,
-      hanh_dong TEXT NOT NULL,
-      noi_dung TEXT,
-      tao_luc TEXT DEFAULT (datetime('now')),
-      FOREIGN KEY (giao_vien_id) REFERENCES giao_vien(id)
-    )");
-  } catch (Throwable $e) { /* ignore */ }
-}
+require __DIR__ . '/migration_nghiep_vu.php';
 
 // Nếu DB đã tồn tại, chạy migrate; nếu lần đầu, seed xong rồi migrate để đảm bảo schema mới nhất
 if ($lan_dau) {
   $luoc_do = file_get_contents(__DIR__ . '/luoc_do.sql');
   $pdo->exec($luoc_do);
-  $stmt = $pdo->prepare("INSERT INTO giao_vien(ten_dang_nhap, mat_khau_bam, vai_tro) VALUES(?,?,?)");
+  $stmt = $pdo->prepare("INSERT INTO giao_vien(ten_dang_nhap, mat_khau_bam, vai_tro, phai_doi_mat_khau) VALUES(?,?,?,1)");
   $stmt->execute(['gv1', password_hash('123456', PASSWORD_DEFAULT), 'ADMIN']);
   $pdo->exec("INSERT INTO lop_hoc(ten) VALUES ('4A'),('4B'),('4C')");
   $pdo->exec("INSERT INTO ly_do(tieu_de, bien_diem, dang_hoat_dong) VALUES ('Giup ban',2,1), ('Hoan thanh som',1,1), ('Noi chuyen rieng',-1,1)");

--- a/config/env.php.example
+++ b/config/env.php.example
@@ -4,7 +4,13 @@ declare(strict_types=1);
 return [
   // Đường dẫn tuyệt đối tới file SQLite
   'db_path' => __DIR__ . '/../data/ung_dung.db',
+  // Đường dẫn tới registry.db (danh sách tổ chức/tenant) - xem config/registry.php
+  'registry_db_path' => __DIR__ . '/../data/registry.db',
   // Đặt tên session riêng nếu cần tách nhiều môi trường trên cùng domain
-  'session_name' => 'dclass_sid'
+  'session_name' => 'dclass_sid',
+  // Secret ngẫu nhiên riêng cho môi trường này, dùng ký cookie "ghi nhớ đăng nhập".
+  // Sinh bằng lệnh: php -r "echo bin2hex(random_bytes(32));"
+  // Nếu để trống, tính năng "ghi nhớ đăng nhập" sẽ tự tắt (an toàn hơn là dùng secret mặc định).
+  'remember_secret' => '',
 ];
 

--- a/config/luoc_do.sql
+++ b/config/luoc_do.sql
@@ -9,6 +9,7 @@ CREATE TABLE giao_vien (
   ten_dang_nhap TEXT UNIQUE NOT NULL,
   mat_khau_bam TEXT NOT NULL,
   vai_tro TEXT DEFAULT 'GV',
+  phai_doi_mat_khau INTEGER DEFAULT 0,
   tao_luc TEXT DEFAULT (datetime('now'))
 );
 CREATE TABLE giao_vien_lop (

--- a/config/luoc_do_registry.sql
+++ b/config/luoc_do_registry.sql
@@ -1,0 +1,28 @@
+PRAGMA foreign_keys = ON;
+-- registry.db: CSDL trung tâm quản lý danh sách tổ chức (tenant), tách biệt
+-- hoàn toàn khỏi CSDL nghiệp vụ từng trường (data/{ma_to_chuc}.db).
+CREATE TABLE to_chuc (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ma_to_chuc TEXT UNIQUE NOT NULL,
+  ten TEXT NOT NULL,
+  domain TEXT,
+  db_path TEXT NOT NULL,
+  dang_hoat_dong INTEGER DEFAULT 1,
+  tao_luc TEXT DEFAULT (datetime('now'))
+);
+-- Tài khoản vận hành nền tảng, tách biệt hoàn toàn với giao_vien của từng tổ chức.
+-- Không có quyền truy cập dữ liệu điểm/học sinh của bất kỳ trường nào.
+CREATE TABLE sieu_quan_tri (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ten_dang_nhap TEXT UNIQUE NOT NULL,
+  mat_khau_bam TEXT NOT NULL,
+  tao_luc TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE nhat_ky_registry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  sieu_quan_tri_id INTEGER,
+  hanh_dong TEXT NOT NULL,
+  noi_dung TEXT,
+  tao_luc TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (sieu_quan_tri_id) REFERENCES sieu_quan_tri(id)
+);

--- a/config/migration_nghiep_vu.php
+++ b/config/migration_nghiep_vu.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Migration cho CSDL nghiệp vụ (mỗi tổ chức/tenant 1 file). Tách riêng khỏi config/db.php
+ * để dùng lại được từ scripts/migrate_all.php (áp dụng cho mọi tenant, không chỉ 1 kết nối hiện tại).
+ */
+if (!function_exists('chay_migration')) {
+  function chay_migration(PDO $pdo): void {
+    // Chuẩn hóa mã loại lịch sử cũ
+    try {
+      $pdo->exec("UPDATE so_cai_diem SET loai='CONG_DIEM' WHERE loai='CONG'");
+      $pdo->exec("UPDATE so_cai_diem SET loai='DOI_DIEM' WHERE loai='QUY_DOI'");
+    } catch (Throwable $e) { /* bảng có thể chưa tồn tại */ }
+    // Đảm bảo cột trong bảng
+    $ensureCols = function(string $table, array $cols) use ($pdo) {
+      try {
+        $info = $pdo->query("PRAGMA table_info($table)")->fetchAll();
+        $exist = array_map(fn($c) => $c['name'] ?? '', $info);
+        foreach ($cols as $col => $ddl) {
+          if (!in_array($col, $exist, true)) { $pdo->exec("ALTER TABLE $table ADD COLUMN $ddl"); }
+        }
+      } catch (Throwable $e) { /* ignore */ }
+    };
+    $ensureCols('hoc_sinh', [
+      'stt' => 'stt INTEGER',
+      'gioi_tinh' => 'gioi_tinh TEXT',
+      'ngay_sinh' => 'ngay_sinh TEXT',
+      'anh_dai_dien_url' => 'anh_dai_dien_url TEXT'
+    ]);
+    $ensureCols('giao_vien', [
+      'vai_tro' => "vai_tro TEXT DEFAULT 'GV'",
+      'phai_doi_mat_khau' => 'phai_doi_mat_khau INTEGER DEFAULT 0'
+    ]);
+    $ensureCols('qua_tang', [
+      'anh_url' => 'anh_url TEXT'
+    ]);
+    // Đảm bảo bảng tồn tại
+    try {
+      $pdo->exec("CREATE TABLE IF NOT EXISTS giao_vien_lop (
+        giao_vien_id INTEGER NOT NULL,
+        lop_hoc_id INTEGER NOT NULL,
+        PRIMARY KEY (giao_vien_id, lop_hoc_id),
+        FOREIGN KEY (giao_vien_id) REFERENCES giao_vien(id) ON DELETE CASCADE,
+        FOREIGN KEY (lop_hoc_id) REFERENCES lop_hoc(id) ON DELETE CASCADE
+      )");
+    } catch (Throwable $e) { /* ignore */ }
+    try {
+      $pdo->exec("CREATE TABLE IF NOT EXISTS reset_khoa (ten_dang_nhap TEXT PRIMARY KEY, het_han INTEGER)");
+    } catch (Throwable $e) { /* ignore */ }
+    try {
+      $pdo->exec("CREATE TABLE IF NOT EXISTS nhat_ky (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        giao_vien_id INTEGER,
+        hanh_dong TEXT NOT NULL,
+        noi_dung TEXT,
+        tao_luc TEXT DEFAULT (datetime('now')),
+        FOREIGN KEY (giao_vien_id) REFERENCES giao_vien(id)
+      )");
+    } catch (Throwable $e) { /* ignore */ }
+  }
+}

--- a/config/registry.php
+++ b/config/registry.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Kết nối/khởi tạo registry.db — CSDL trung tâm quản lý danh sách tổ chức (tenant).
+ * Tách biệt hoàn toàn khỏi config/db.php (CSDL nghiệp vụ theo từng tổ chức).
+ * Không đụng tới session/header — chỉ lo phần kết nối CSDL, dùng được cả từ CLI lẫn web.
+ */
+
+function duong_dan_registry_db(): string {
+  $env = [];
+  $env_file = __DIR__ . '/env.php';
+  if (file_exists($env_file)) {
+    $env = require $env_file;
+  }
+  return $env['registry_db_path'] ?? (__DIR__ . '/../data/registry.db');
+}
+
+function chay_migration_registry(PDO $pdo): void {
+  $ensureCols = function (string $table, array $cols) use ($pdo) {
+    try {
+      $info = $pdo->query("PRAGMA table_info($table)")->fetchAll();
+      $exist = array_map(fn($c) => $c['name'] ?? '', $info);
+      foreach ($cols as $col => $ddl) {
+        if (!in_array($col, $exist, true)) {
+          $pdo->exec("ALTER TABLE $table ADD COLUMN $ddl");
+        }
+      }
+    } catch (Throwable $e) { /* bảng có thể chưa tồn tại */ }
+  };
+  try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS to_chuc (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ma_to_chuc TEXT UNIQUE NOT NULL,
+      ten TEXT NOT NULL,
+      domain TEXT,
+      db_path TEXT NOT NULL,
+      dang_hoat_dong INTEGER DEFAULT 1,
+      tao_luc TEXT DEFAULT (datetime('now'))
+    )");
+  } catch (Throwable $e) { /* ignore */ }
+  try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS sieu_quan_tri (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ten_dang_nhap TEXT UNIQUE NOT NULL,
+      mat_khau_bam TEXT NOT NULL,
+      tao_luc TEXT DEFAULT (datetime('now'))
+    )");
+  } catch (Throwable $e) { /* ignore */ }
+  try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS nhat_ky_registry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      sieu_quan_tri_id INTEGER,
+      hanh_dong TEXT NOT NULL,
+      noi_dung TEXT,
+      tao_luc TEXT DEFAULT (datetime('now')),
+      FOREIGN KEY (sieu_quan_tri_id) REFERENCES sieu_quan_tri(id)
+    )");
+  } catch (Throwable $e) { /* ignore */ }
+}
+
+function ket_noi_registry(): PDO {
+  static $pdo = null;
+  if ($pdo !== null) return $pdo;
+  $duong_dan = duong_dan_registry_db();
+  $thu_muc = dirname($duong_dan);
+  if (!is_dir($thu_muc)) {
+    @mkdir($thu_muc, 0777, true);
+  }
+  $lan_dau = !file_exists($duong_dan);
+  $pdo = new PDO('sqlite:' . $duong_dan);
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+  $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+  $pdo->exec('PRAGMA foreign_keys = ON');
+  if ($lan_dau) {
+    $luoc_do = file_get_contents(__DIR__ . '/luoc_do_registry.sql');
+    $pdo->exec($luoc_do);
+  }
+  chay_migration_registry($pdo);
+  return $pdo;
+}
+
+/**
+ * Tra registry theo mã tổ chức, trả về bản ghi to_chuc hoặc null nếu không tồn tại/bị khoá.
+ */
+function tim_to_chuc_theo_ma(PDO $registry, string $ma_to_chuc): ?array {
+  $st = $registry->prepare('SELECT * FROM to_chuc WHERE ma_to_chuc = ?');
+  $st->execute([$ma_to_chuc]);
+  $tc = $st->fetch();
+  return $tc ?: null;
+}

--- a/lib/ghi_nho.php
+++ b/lib/ghi_nho.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 // Hỗ trợ cookie "ghi nhớ đăng nhập"
 
 function bi_mat_he_thong(): string {
-  $pepper = 'DClass_Pepper_v1';
-  return hash('sha256', __DIR__ . '|' . $pepper);
+  // Secret riêng theo môi trường, cấu hình trong config/env.php (khoá 'remember_secret').
+  // Không dùng giá trị mặc định cố định trong code: nếu thiếu, tính năng "ghi nhớ đăng nhập" sẽ tự tắt.
+  $secret = $GLOBALS['env']['remember_secret'] ?? '';
+  return is_string($secret) ? $secret : '';
 }
 
 function tao_chu_ky_cookie(string $ten_dang_nhap, string $mat_khau_bam, string $user_agent): string {
@@ -14,10 +16,11 @@ function tao_chu_ky_cookie(string $ten_dang_nhap, string $mat_khau_bam, string $
 }
 
 function dat_cookie_ghi_nho(string $ten_dang_nhap, string $mat_khau_bam): void {
+  if (bi_mat_he_thong() === '') return; // Chưa cấu hình remember_secret -> không phát cookie
   $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
   $token = tao_chu_ky_cookie($ten_dang_nhap, $mat_khau_bam, $ua);
   $expires = time() + 60*60*24*30; // 30 ngày
-  $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+  $secure = dang_https();
   setcookie('gv_u', $ten_dang_nhap, [
     'expires' => $expires,
     'path' => '/',
@@ -47,17 +50,21 @@ function xoa_cookie_ghi_nho(): void {
 }
 
 function thu_cookie_ghi_nho(PDO $pdo): bool {
+  if (bi_mat_he_thong() === '') return false;
   $ten = $_COOKIE['gv_u'] ?? '';
   $tok = $_COOKIE['gv_t'] ?? '';
   if ($ten === '' || $tok === '') return false;
-  $st = $pdo->prepare('SELECT id, ten_dang_nhap, mat_khau_bam FROM giao_vien WHERE ten_dang_nhap=?');
+  $st = $pdo->prepare('SELECT id, ten_dang_nhap, mat_khau_bam, vai_tro, phai_doi_mat_khau FROM giao_vien WHERE ten_dang_nhap=?');
   $st->execute([$ten]);
   $gv = $st->fetch(); if (!$gv) return false;
   $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
   $ky = tao_chu_ky_cookie($gv['ten_dang_nhap'], $gv['mat_khau_bam'], $ua);
   if (!hash_equals($ky, $tok)) return false;
+  session_regenerate_id(true); // chống session fixation khi tự đăng nhập lại qua cookie
   $_SESSION['giao_vien_id'] = (int)$gv['id'];
   $_SESSION['ten_dang_nhap'] = $gv['ten_dang_nhap'];
+  $_SESSION['vai_tro'] = $gv['vai_tro'] ?? 'GV';
+  $_SESSION['phai_doi_mat_khau'] = (bool)((int)($gv['phai_doi_mat_khau'] ?? 0));
   return true;
 }
 

--- a/lib/tro_giup.php
+++ b/lib/tro_giup.php
@@ -7,6 +7,14 @@ function json_phan_hoi($ok, $du_lieu=null, $thong_bao='') {
 }
 function yeu_cau_dang_nhap() {
   if (!isset($_SESSION['giao_vien_id'])) { http_response_code(401); json_phan_hoi(false, null, 'chua_dang_nhap'); }
+  if (!empty($_SESSION['phai_doi_mat_khau'])) {
+    $script = $_SERVER['SCRIPT_NAME'] ?? '';
+    // Chỉ cho phép qua trang quản trị tài khoản (nơi có action đổi mật khẩu) khi đang bị buộc đổi mật khẩu
+    if (strpos($script, 'giao_vien_quan_tri.php') === false) {
+      http_response_code(403);
+      json_phan_hoi(false, null, 'phai_doi_mat_khau');
+    }
+  }
 }
 function than_json() {
   $raw = file_get_contents('php://input'); $j = json_decode($raw, true);

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,10 @@
+# Mở lại quyền truy cập cho public/ (bị chặn mặc định bởi .htaccess ở gốc repo).
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>

--- a/public/bao_cao.php
+++ b/public/bao_cao.php
@@ -2,6 +2,7 @@
 header('Content-Type: text/html; charset=utf-8');
 require __DIR__ . '/../config/db.php'; require __DIR__ . '/../lib/tro_giup.php';
 if (!isset($_SESSION['giao_vien_id'])) { header('Location: dang_nhap.php'); exit; }
+if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); exit; }
 $la_admin = (($_SESSION['vai_tro'] ?? '') === 'ADMIN');
 // Lớp được gán cho GV (admin thấy tất cả)
 $lop_gan = [];

--- a/public/cau_hinh.php
+++ b/public/cau_hinh.php
@@ -2,10 +2,17 @@
 require __DIR__ . '/../config/db.php'; require __DIR__ . '/../lib/tro_giup.php';
 if (!isset($_SESSION['giao_vien_id'])) { header('Location: dang_nhap.php'); exit; }
 if (($_SESSION['vai_tro'] ?? '') !== 'ADMIN') { header('Location: trang_chinh.php'); exit; }
+$can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
 ?><!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cấu hình hệ thống</title>
 <link rel="stylesheet" href="vendor/bootswatch/bootstrap.min.css"><link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.css"><link rel="stylesheet" href="vendor/aos/aos.css"><link rel="stylesheet" href="vendor/theme.css"><link rel="stylesheet" href="vendor/custom_file.css"><link rel="stylesheet" href="vendor/date_picker.css"><style>.ld-stepper .ld-stepper-btns{min-width:38px;height:100%;}.ld-stepper .ld-stepper-btns .btn{padding:4px 0;line-height:1;height:50%;border-radius:0;}.ld-stepper .ld-stepper-btns .btn:first-child{border-top-right-radius:.375rem;}.ld-stepper .ld-stepper-btns .btn:last-child{border-bottom-right-radius:.375rem;}.ld-bd-wrap{position:relative;}.ld-bd-wrap input{padding-left:24px;}#ld_bien_diem::-webkit-outer-spin-button,#ld_bien_diem::-webkit-inner-spin-button{-webkit-appearance:none;margin:0;}#ld_bien_diem{-moz-appearance:textfield;}.ld-bd-plus{position:absolute;left:10px;top:50%;transform:translateY(-50%);color:#0d6efd;font-weight:600;pointer-events:none;font-size:.95rem;}</style></head><body><?php include __DIR__ . '/_nav.php'; ?>
 <div class="container py-3">
+  <?php if ($can_doi_mk_bat_buoc): ?>
+  <div class="alert alert-warning d-flex align-items-center gap-2" role="alert">
+    <i class="bi bi-shield-exclamation"></i>
+    <div>Tài khoản của bạn đang dùng mật khẩu mặc định. Vui lòng đổi mật khẩu ngay bên dưới trước khi tiếp tục sử dụng hệ thống.</div>
+  </div>
+  <?php endif; ?>
   <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Cấu hình hệ thống</h5></div>
 
   <ul class="nav nav-tabs mt-3 nav-square" id="tab" role="tablist">
@@ -798,7 +805,11 @@ function hsSyncLopSelectOnce(){
     msg.textContent='';
     if (!mk_moi || mk_moi !== mk_lai) { msg.textContent='Mật khẩu nhập lại không khớp'; return; }
     const j = await jfetch('../api/giao_vien_quan_tri.php?hanh_dong=doi_mat_khau',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({mat_khau_cu:mk_cu, mat_khau_moi:mk_moi})});
-    if (j.ok) { msg.textContent='Đã đổi mật khẩu'; document.getElementById('gv_mk_cu').value=''; document.getElementById('gv_mk_moi').value=''; document.getElementById('gv_mk_lai').value=''; }
+    if (j.ok) {
+      msg.textContent='Đã đổi mật khẩu';
+      document.getElementById('gv_mk_cu').value=''; document.getElementById('gv_mk_moi').value=''; document.getElementById('gv_mk_lai').value='';
+      <?php if ($can_doi_mk_bat_buoc): ?>location.reload();<?php endif; ?>
+    }
     else { msg.textContent=j.thong_bao||'Lỗi'; }
   };
   const btnThem = document.getElementById('gv_them');

--- a/public/hoc_sinh_quan_ly.php
+++ b/public/hoc_sinh_quan_ly.php
@@ -3,6 +3,7 @@ require __DIR__ . '/../config/db.php';
 require __DIR__ . '/../lib/tro_giup.php';
 header('Content-Type: text/html; charset=utf-8');
 if (!isset($_SESSION['giao_vien_id'])) { header('Location: dang_nhap.php'); exit; }
+if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); exit; }
 ?>
 <!doctype html>
 <html>

--- a/public/lich_su.php
+++ b/public/lich_su.php
@@ -2,6 +2,7 @@
 header('Content-Type: text/html; charset=utf-8');
 require __DIR__ . '/../config/db.php'; require __DIR__ . '/../lib/tro_giup.php';
 if (!isset($_SESSION['giao_vien_id'])) { header('Location: dang_nhap.php'); exit; }
+if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); exit; }
 ?><!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Lịch sử</title>
 <link rel="stylesheet" href="vendor/bootswatch/bootstrap.min.css"><link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.css"><link rel="stylesheet" href="vendor/aos/aos.css"><link rel="stylesheet" href="vendor/theme.css"><link rel="stylesheet" href="vendor/date_picker.css"></head><body>

--- a/public/trang_chinh.php
+++ b/public/trang_chinh.php
@@ -3,6 +3,7 @@ require __DIR__ . '/../config/db.php';
 require __DIR__ . '/../lib/tro_giup.php';
 header('Content-Type: text/html; charset=utf-8');
 if (!isset($_SESSION['giao_vien_id'])) { header('Location: dang_nhap.php'); exit; }
+if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); exit; }
 ?>
 <!doctype html>
 <html>

--- a/scripts/migrate_all.php
+++ b/scripts/migrate_all.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Chạy chay_migration() cho TẤT CẢ tổ chức đăng ký trong registry.db, kể cả
+ * tổ chức lâu không ai đăng nhập (chay_migration() trong config/db.php chỉ chạy
+ * khi có request tới đúng DB đó). Dùng khi nâng cấp schema, chạy thủ công hoặc
+ * như 1 bước trong quy trình deploy.
+ *
+ * Cách dùng: php scripts/migrate_all.php
+ */
+
+require __DIR__ . '/../config/registry.php';
+require __DIR__ . '/../config/migration_nghiep_vu.php';
+
+$registry = ket_noi_registry();
+$to_chuc_list = $registry->query('SELECT id, ma_to_chuc, ten, db_path FROM to_chuc ORDER BY id ASC')->fetchAll();
+
+if (!$to_chuc_list) {
+  echo "Chua co to chuc nao trong registry." . PHP_EOL;
+  exit(0);
+}
+
+$thanh_cong = 0;
+$loi = 0;
+foreach ($to_chuc_list as $tc) {
+  $db_path = (string)$tc['db_path'];
+  if (!file_exists($db_path)) {
+    echo "[BO QUA] {$tc['ma_to_chuc']}: khong tim thay file {$db_path}" . PHP_EOL;
+    $loi++;
+    continue;
+  }
+  try {
+    $pdo = new PDO('sqlite:' . $db_path);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+    $pdo->exec('PRAGMA foreign_keys = ON');
+    chay_migration($pdo);
+    echo "[OK] {$tc['ma_to_chuc']} ({$tc['ten']})" . PHP_EOL;
+    $thanh_cong++;
+  } catch (Throwable $e) {
+    echo "[LOI] {$tc['ma_to_chuc']}: " . $e->getMessage() . PHP_EOL;
+    $loi++;
+  }
+}
+
+echo "Hoan tat: {$thanh_cong} thanh cong, {$loi} loi/bo qua." . PHP_EOL;
+if ($loi > 0) {
+  exit(1);
+}

--- a/scripts/tao_sieu_quan_tri.php
+++ b/scripts/tao_sieu_quan_tri.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CLI: tao tai khoan sieu_quan_tri (van hanh nen tang, quan ly danh sach to chuc).
+ * Khong tu seed tai khoan mac dinh khi khoi tao registry.db - phai tao thu cong
+ * bang script nay de tranh lap lai loi "mat khau mac dinh doan duoc" (xem P0.10).
+ *
+ * Cach dung:
+ *   php scripts/tao_sieu_quan_tri.php --ten_dang_nhap=van_hanh --mat_khau=xxxx
+ */
+
+require __DIR__ . '/../config/registry.php';
+
+$options = getopt('', ['ten_dang_nhap:', 'mat_khau:']);
+
+function loi_thoat_sqt(string $msg): never {
+  fwrite(STDERR, $msg . PHP_EOL);
+  exit(1);
+}
+
+$ten = trim((string)($options['ten_dang_nhap'] ?? ''));
+$mat_khau = (string)($options['mat_khau'] ?? '');
+
+if ($ten === '' || $mat_khau === '') {
+  loi_thoat_sqt('Thieu --ten_dang_nhap hoac --mat_khau. Vi du: php scripts/tao_sieu_quan_tri.php --ten_dang_nhap=van_hanh --mat_khau=xxxx');
+}
+if (strlen($mat_khau) < 8) {
+  loi_thoat_sqt('Mat khau qua ngan, can toi thieu 8 ky tu.');
+}
+
+$registry = ket_noi_registry();
+$st = $registry->prepare('SELECT 1 FROM sieu_quan_tri WHERE ten_dang_nhap=?');
+$st->execute([$ten]);
+if ($st->fetchColumn()) {
+  loi_thoat_sqt("Tai khoan sieu quan tri '{$ten}' da ton tai.");
+}
+
+$registry->prepare('INSERT INTO sieu_quan_tri(ten_dang_nhap, mat_khau_bam) VALUES(?,?)')
+         ->execute([$ten, password_hash($mat_khau, PASSWORD_DEFAULT)]);
+
+echo "Da tao tai khoan sieu quan tri '{$ten}'." . PHP_EOL;

--- a/scripts/tao_to_chuc.php
+++ b/scripts/tao_to_chuc.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CLI provisioning: tạo 1 tổ chức (tenant) mới.
+ * - Tạo file data/{ma_to_chuc}.db từ config/luoc_do.sql, seed tài khoản ADMIN đầu tiên
+ *   (bắt buộc đổi mật khẩu ngay lần đăng nhập đầu).
+ * - Đăng ký tổ chức vào registry.db (bảng to_chuc).
+ *
+ * Cách dùng:
+ *   php scripts/tao_to_chuc.php --ma=truong_abc --ten="Truong Tieu Hoc ABC" --admin=admin1 [--mat_khau=xxxx]
+ * Nếu không truyền --mat_khau, hệ thống tự sinh mật khẩu ngẫu nhiên và in ra 1 lần duy nhất.
+ */
+
+require __DIR__ . '/../config/registry.php';
+
+$options = getopt('', ['ma:', 'ten:', 'admin::', 'mat_khau::']);
+
+function loi_thoat(string $msg): never {
+  fwrite(STDERR, $msg . PHP_EOL);
+  exit(1);
+}
+
+$ma_to_chuc = trim((string)($options['ma'] ?? ''));
+$ten = trim((string)($options['ten'] ?? ''));
+$admin_user = trim((string)($options['admin'] ?? 'admin'));
+$mat_khau = isset($options['mat_khau']) ? (string)$options['mat_khau'] : null;
+
+if ($ma_to_chuc === '' || $ten === '') {
+  loi_thoat('Thieu --ma hoac --ten. Vi du: php scripts/tao_to_chuc.php --ma=truong_abc --ten="Truong ABC" --admin=admin1');
+}
+if (!preg_match('/^[a-z0-9_]{2,32}$/', $ma_to_chuc)) {
+  loi_thoat('Ma to chuc chi duoc chua chu thuong/so/gach duoi, 2-32 ky tu (vd: truong_abc).');
+}
+if ($admin_user === '') {
+  loi_thoat('Ten dang nhap admin khong duoc rong.');
+}
+
+$registry = ket_noi_registry();
+if (tim_to_chuc_theo_ma($registry, $ma_to_chuc) !== null) {
+  loi_thoat("Ma to chuc '{$ma_to_chuc}' da ton tai trong registry.");
+}
+
+$data_dir = __DIR__ . '/../data';
+if (!is_dir($data_dir)) {
+  @mkdir($data_dir, 0777, true);
+}
+$db_path = $data_dir . '/' . $ma_to_chuc . '.db';
+if (file_exists($db_path)) {
+  loi_thoat("File CSDL '{$db_path}' da ton tai - khong ghi de.");
+}
+
+$mat_khau_tu_sinh = false;
+if ($mat_khau === null || $mat_khau === '') {
+  $mat_khau = bin2hex(random_bytes(6)); // 12 ky tu hex ngau nhien
+  $mat_khau_tu_sinh = true;
+}
+
+$pdo = new PDO('sqlite:' . $db_path);
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+$pdo->exec('PRAGMA foreign_keys = ON');
+$luoc_do = file_get_contents(__DIR__ . '/../config/luoc_do.sql');
+$pdo->exec($luoc_do);
+$pdo->prepare('INSERT INTO giao_vien(ten_dang_nhap, mat_khau_bam, vai_tro, phai_doi_mat_khau) VALUES(?,?,?,1)')
+    ->execute([$admin_user, password_hash($mat_khau, PASSWORD_DEFAULT), 'ADMIN']);
+
+$registry->prepare('INSERT INTO to_chuc(ma_to_chuc, ten, db_path, dang_hoat_dong) VALUES(?,?,?,1)')
+         ->execute([$ma_to_chuc, $ten, $db_path]);
+
+echo "Da tao to chuc '{$ma_to_chuc}' ({$ten})." . PHP_EOL;
+echo "CSDL: {$db_path}" . PHP_EOL;
+echo "Tai khoan ADMIN dau tien: {$admin_user}" . PHP_EOL;
+if ($mat_khau_tu_sinh) {
+  echo "Mat khau tam (chi hien 1 lan, bat buoc doi ngay khi dang nhap): {$mat_khau}" . PHP_EOL;
+}

--- a/tools/cai_dat.php
+++ b/tools/cai_dat.php
@@ -67,7 +67,7 @@ function seed_mau(PDO $pdo): void
   if ($da_co > 0) {
     return;
   }
-  $pdo->prepare('INSERT INTO giao_vien(ten_dang_nhap, mat_khau_bam, vai_tro) VALUES(?,?,?)')
+  $pdo->prepare('INSERT INTO giao_vien(ten_dang_nhap, mat_khau_bam, vai_tro, phai_doi_mat_khau) VALUES(?,?,?,1)')
       ->execute(['gv1', password_hash('123456', PASSWORD_DEFAULT), 'ADMIN']);
   $pdo->exec("INSERT INTO lop_hoc(ten) VALUES ('4A'),('4B'),('4C')");
   $pdo->exec("INSERT INTO ly_do(tieu_de, bien_diem, dang_hoat_dong) VALUES ('Giup ban',2,1), ('Hoan thanh som',1,1), ('Noi chuyen rieng',-1,1)");

--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -1,5 +1,14 @@
 Options -Indexes
 
+# Mở lại quyền truy cập cho upload/ (bị chặn mặc định bởi .htaccess ở gốc repo).
+<IfModule mod_authz_core.c>
+  Require all granted
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Allow from all
+</IfModule>
+
 # Ngăn thực thi mã trong thư mục upload (chỉ cho phép serve tĩnh)
 <FilesMatch "\.(php|phar|phtml|pht|phps|cgi|pl|asp|aspx|jsp|sh|bash)$">
   Require all denied


### PR DESCRIPTION
## Summary
- **Security fixes (P0)**: privilege escalation via `cap_nhat_lop` and unguarded `lop_hoc_quan_tri.php` actions, IDOR letting any teacher edit/disable students outside their assigned classes, hardcoded remember-me cookie pepper, weak session cookie config, session fixation, and a default admin (`gv1/123456`) with no forced password change.
- **Online-deploy hardening**: security headers + CSP, HTTPS detection behind reverse proxy, corrected Apache/dev-server docroot guidance (JS calls `../api/...` relative paths — deny-by-default `.htaccess` at repo root with explicit allow in `public/`, `api/`, `upload/`).
- **Multi-tenant foundation (DB-per-tenant)**: `registry.db` with `to_chuc` (tenant) + `sieu_quan_tri` (platform admin) tables, `scripts/tao_to_chuc.php` (provision tenant), `scripts/tao_sieu_quan_tri.php` (create platform admin, no default seed), `scripts/migrate_all.php` (migrate schema across all tenant DBs). Login/session tenant-resolution and per-tenant data isolation are tracked as follow-up work, not yet wired into the live app.

## Test plan
- [x] `php -l` on every changed/new PHP file
- [x] `composer test` (PHPUnit) — 5/5 passing, no regressions
- [x] `composer phpstan` — no errors
- [x] End-to-end smoke test via PHP built-in server: default admin login → locked out of other APIs until password change → wrong old-password rejected → correct change succeeds → unlocked, `phai_doi_mat_khau` cleared in DB
- [x] End-to-end test of `tao_to_chuc.php`/`tao_sieu_quan_tri.php`/`migrate_all.php`: create tenants, reject duplicates/invalid codes, simulate an outdated tenant DB and confirm `migrate_all.php` repairs its schema
- [ ] Manual review of `.htaccess` rules against a real Apache instance (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)