### PR TITLE
Refactor mobile styling to be consistent across the app

### DIFF
--- a/public/bao_cao.php
+++ b/public/bao_cao.php
@@ -106,25 +106,25 @@ if ($top5_values) {
   </div>
   <div class="row g-3 mt-1" data-aos="fade-up">
     <div class="col-12"><div class="card shadow-sm"><div class="card-body">
-      <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Xu hướng 30 ngày</h5><div class="text-muted small">Điểm cộng / điểm đổi / giao dịch</div></div>
-      <div class="mt-2" style="height:280px;"><?php if ($xu_huong_nhan): ?><canvas id="chart-xu-huong" aria-label="Biểu đồ xu hướng 30 ngày" role="img"></canvas><?php else: ?><div class="text-muted small">Chưa có dữ liệu</div><?php endif; ?></div>
+      <div class="d-flex align-items-center justify-content-between flex-wrap gap-2"><h5 class="ribbon-title-modern mb-0">Xu hướng 30 ngày</h5><div class="text-muted small">Điểm cộng / điểm đổi / giao dịch</div></div>
+      <div class="mt-2 chart-box-lg"><?php if ($xu_huong_nhan): ?><canvas id="chart-xu-huong" aria-label="Biểu đồ xu hướng 30 ngày" role="img"></canvas><?php else: ?><div class="text-muted small">Chưa có dữ liệu</div><?php endif; ?></div>
     </div></div></div>
   </div>
   <div class="row g-3 mt-1" data-aos="fade-up">
     <div class="col-lg-6"><div class="card shadow-sm h-100"><div class="card-body">
       <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Top 3 quà được đổi</h5></div>
-      <div class="mt-3" style="height:260px;"><?php if ($top_qua): ?><canvas id="chart-qua" aria-label="Biểu đồ top quà đổi" role="img"></canvas><?php else: ?><div class="text-muted small">Chưa có giao dịch đổi quà</div><?php endif; ?></div>
+      <div class="mt-3 chart-box"><?php if ($top_qua): ?><canvas id="chart-qua" aria-label="Biểu đồ top quà đổi" role="img"></canvas><?php else: ?><div class="text-muted small">Chưa có giao dịch đổi quà</div><?php endif; ?></div>
     </div></div></div>
     <div class="col-lg-6"><div class="card shadow-sm h-100"><div class="card-body">
       <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Top lý do cộng điểm</h5></div>
-      <div class="mt-3" style="height:260px;"><?php if ($top_ly_do): ?><canvas id="chart-ly-do" aria-label="Biểu đồ lý do cộng điểm" role="img"></canvas><?php else: ?><div class="text-muted small">Chưa có giao dịch cộng điểm</div><?php endif; ?></div>
+      <div class="mt-3 chart-box"><?php if ($top_ly_do): ?><canvas id="chart-ly-do" aria-label="Biểu đồ lý do cộng điểm" role="img"></canvas><?php else: ?><div class="text-muted small">Chưa có giao dịch cộng điểm</div><?php endif; ?></div>
     </div></div></div>
   </div>
   <div class="row g-3 mt-1" data-aos="fade-up">
     <div class="col-12"><div class="card shadow-sm"><div class="card-body">
       <div class="d-flex align-items-center justify-content-between flex-wrap gap-2"><h5 class="ribbon-title-modern mb-0">Phân bố top 5 số dư</h5></div>
       <?php if ($top5): ?>
-        <div class="mt-3" style="height:260px;"><canvas id="chart-top5" aria-label="Histogram top 5 số dư" role="img"></canvas></div>
+        <div class="mt-3 chart-box"><canvas id="chart-top5" aria-label="Histogram top 5 số dư" role="img"></canvas></div>
         <?php if ($top5_thong_ke): ?>
           
         <?php endif; ?>

--- a/public/cau_hinh.php
+++ b/public/cau_hinh.php
@@ -40,8 +40,8 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
           <button class="btn btn-primary btn-sm" id="ld_them">Thêm</button>
         </div></div></div>
         <div class="col-md-8"><div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
-          <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Danh sách</h5><small class="text-muted">Bấm bật/tắt, sửa hoặc xóa</small></div>
-          <div class="table-responsive mt-2">
+          <div class="d-flex align-items-center justify-content-between flex-wrap gap-2"><h5 class="ribbon-title-modern mb-0">Danh sách</h5><small class="text-muted">Bấm bật/tắt, sửa hoặc xóa</small></div>
+          <div class="table-responsive table-responsive-stack mt-2">
             <table class="table table-sm align-middle"><thead><tr><th>#</th><th>Tiêu đề</th><th>Biến điểm</th><th>Trạng thái</th><th></th></tr></thead><tbody id="ld_ds"></tbody></table>
           </div>
         </div></div></div>
@@ -58,8 +58,8 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
           <button class="btn btn-primary btn-sm" id="q_them">Thêm</button>
         </div></div></div>
         <div class="col-md-8"><div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
-          <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Danh sách</h5><small class="text-muted">Bấm bật/tắt, sửa hoặc xóa</small></div>
-          <div class="table-responsive mt-2">
+          <div class="d-flex align-items-center justify-content-between flex-wrap gap-2"><h5 class="ribbon-title-modern mb-0">Danh sách</h5><small class="text-muted">Bấm bật/tắt, sửa hoặc xóa</small></div>
+          <div class="table-responsive table-responsive-stack mt-2">
             <table class="table table-sm align-middle"><thead><tr><th>#</th><th>Ảnh</th><th>Tên</th><th>Giá điểm</th><th>Tồn kho</th><th>Trạng thái</th><th></th></tr></thead><tbody id="q_ds"></tbody></table>
           </div>
         </div></div></div>
@@ -73,8 +73,8 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
           <button class="btn btn-primary btn-sm" id="l_them">Thêm</button>
         </div></div></div>
         <div class="col-md-8"><div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
-          <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Danh sách</h5><small class="text-muted">Bấm bật/tắt, sửa hoặc xóa</small></div>
-          <div class="table-responsive mt-2">
+          <div class="d-flex align-items-center justify-content-between flex-wrap gap-2"><h5 class="ribbon-title-modern mb-0">Danh sách</h5><small class="text-muted">Bấm bật/tắt, sửa hoặc xóa</small></div>
+          <div class="table-responsive table-responsive-stack mt-2">
             <table class="table table-sm align-middle"><thead><tr><th>#</th><th>Tên</th><th>Trạng thái</th><th></th></tr></thead><tbody id="l_ds"></tbody></table>
           </div>
         </div></div></div>
@@ -96,10 +96,10 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
           <div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
             <h5 class="ribbon-title-modern">Thêm học sinh</h5>
             <div class="row g-2">
-              <div class="col-4"><input id="ma" class="form-control" placeholder="Mã (tùy chọn)"></div>
-              <div class="col-8"><input id="ho_ten" class="form-control" placeholder="Họ tên"></div>
-              <div class="col-6 mt-2"><input id="anh_dai_dien_url" class="form-control" placeholder="Ảnh đại diện URL"></div>
-              <div class="col-3 mt-2">
+              <div class="col-12 col-sm-4"><input id="ma" class="form-control" placeholder="Mã (tùy chọn)"></div>
+              <div class="col-12 col-sm-8"><input id="ho_ten" class="form-control" placeholder="Họ tên"></div>
+              <div class="col-12 col-sm-6 mt-2"><input id="anh_dai_dien_url" class="form-control" placeholder="Ảnh đại diện URL"></div>
+              <div class="col-6 col-sm-3 mt-2">
                 <select id="gioi_tinh" class="form-select">
                   <option value="">Giới tính...</option>
                   <option value="NAM">Nam</option>
@@ -107,22 +107,22 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
                   <option value="KHAC">Khác</option>
                 </select>
               </div>
-              <div class="col-3 mt-2"><input id="ngay_sinh" type="text" class="form-control date-picker" placeholder="Ngày sinh" data-datepicker="1"></div>
+              <div class="col-6 col-sm-3 mt-2"><input id="ngay_sinh" type="text" class="form-control date-picker" placeholder="Ngày sinh" data-datepicker="1"></div>
             </div>
             <div class="mt-2"><button id="them" class="btn btn-primary">Thêm</button><span id="msg" class="ms-2 small text-muted"></span></div>
             <hr>
-            <div class="d-flex align-items-center gap-2">
-              <div class="me-auto" style="max-width:320px;">
+            <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2">
+              <div class="me-sm-auto" style="max-width:320px;">
                 <label class="form-label">Nhập CSV</label>
                 <div class="custom-file-input-sm position-relative">
                   <input type="file" id="csv_file" accept=".csv" class="form-control form-control-sm" aria-label="Chọn file CSV">
                   <span class="custom-file-label" id="csv_file_label">Chưa chọn tệp</span>
                 </div>
               </div>
-              <div class="pt-4">
+              <div class="pt-sm-4">
                 <div class="d-flex gap-2">
-                  <button id="nhap_csv" class="btn btn-outline-primary btn-sm px-3">Nhập CSV</button>
-                  <button id="xuat_csv" class="btn btn-outline-primary btn-sm px-3">Xuất CSV</button>
+                  <button id="nhap_csv" class="btn btn-outline-primary btn-sm px-3 flex-fill">Nhập CSV</button>
+                  <button id="xuat_csv" class="btn btn-outline-primary btn-sm px-3 flex-fill">Xuất CSV</button>
                 </div>
               </div>
             </div>
@@ -138,18 +138,18 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
                   <div class="small text-muted"><span id="ct_lop_text"></span> - <span id="ct_trang_thai"></span></div>
                 </div>
               </div>
-              <div class="d-flex align-items-center gap-2 mt-2">
+              <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2 mt-2">
                 <input type="file" id="up_anh" accept="image/*" class="form-control form-control-sm" style="max-width:320px">
                 <button id="btn_up_anh" class="btn btn-outline-primary btn-sm">Upload ảnh</button>
                 <button id="btn_toggle" class="btn btn-outline-warning btn-sm">Tắt</button>
               </div>
               <div id="ct_msg" class="small text-muted mt-1"></div>
               <div class="row g-2 mt-2">
-                <div class="col-4"><label class="form-label">Mã</label><input id="ct_ma" class="form-control"></div>
-                <div class="col-8"><label class="form-label">Họ tên</label><input id="ct_ho_ten" class="form-control"></div>
-                <div class="col-6"><label class="form-label">Lớp</label><select id="ct_lop" class="form-select"></select></div>
-                <div class="col-3"><label class="form-label">Giới tính</label><select id="ct_gioi" class="form-select"><option value="">--</option><option value="NAM">Nam</option><option value="NU">Nữ</option><option value="KHAC">Khác</option></select></div>
-                <div class="col-3"><label class="form-label">Ngày sinh</label><input id="ct_ngay" type="text" class="form-control date-picker" data-datepicker="1" placeholder="dd/mm/yyyy"></div>
+                <div class="col-12 col-sm-4"><label class="form-label">Mã</label><input id="ct_ma" class="form-control"></div>
+                <div class="col-12 col-sm-8"><label class="form-label">Họ tên</label><input id="ct_ho_ten" class="form-control"></div>
+                <div class="col-12 col-sm-6"><label class="form-label">Lớp</label><select id="ct_lop" class="form-select"></select></div>
+                <div class="col-6 col-sm-3"><label class="form-label">Giới tính</label><select id="ct_gioi" class="form-select"><option value="">--</option><option value="NAM">Nam</option><option value="NU">Nữ</option><option value="KHAC">Khác</option></select></div>
+                <div class="col-6 col-sm-3"><label class="form-label">Ngày sinh</label><input id="ct_ngay" type="text" class="form-control date-picker" data-datepicker="1" placeholder="dd/mm/yyyy"></div>
               </div>
               <div class="mt-2"><button id="btn_luu" class="btn btn-primary btn-sm">Lưu thay đổi</button></div>
             </div>
@@ -264,8 +264,8 @@ async function ldNap(){ const j = await jfetch('../api/ly_do_quan_tri.php'); if(
     tr.dataset.id = x.id;
     tr.dataset.tieu_de = x.tieu_de;
     tr.dataset.bien_diem = x.bien_diem;
-    tr.innerHTML = `<td>${x.id}</td><td>${x.tieu_de}</td><td>${formatSigned(x.bien_diem)}</td><td>${badge(x.dang_hoat_dong)}</td>
-    <td class="text-end">
+    tr.innerHTML = `<td data-label="#">${x.id}</td><td data-label="Tiêu đề">${x.tieu_de}</td><td data-label="Biến điểm">${formatSigned(x.bien_diem)}</td><td data-label="Trạng thái">${badge(x.dang_hoat_dong)}</td>
+    <td class="text-end stack-actions">
       <div class="d-flex flex-nowrap justify-content-end gap-2">
         <button class="btn btn-outline-primary rounded-pill px-3 py-2">Sửa</button>
         <button class="btn btn-outline-warning rounded-pill px-3 py-2">${x.dang_hoat_dong? 'Tắt':'Bật'}</button>
@@ -304,8 +304,8 @@ async function qNap(){ const j = await jfetch('../api/qua_tang_quan_tri.php'); i
     tr.dataset.ton_kho = x.ton_kho;
     tr.dataset.anh_url = x.anh_url || '';
     const av = (x.anh_url && String(x.anh_url).trim()!=='') ? x.anh_url : '../upload/avatar/default.svg';
-    tr.innerHTML = `<td>${x.id}</td><td><img src="${av}" alt="" style="width:32px;height:32px;object-fit:cover;border:1px solid #ddd;border-radius:6px" onerror="this.onerror=null;this.src='../upload/avatar/default.svg';"></td><td>${x.ten}</td><td>${x.gia_diem}</td><td>${x.ton_kho}</td><td>${badge(x.dang_hoat_dong)}</td>
-    <td class="text-end">
+    tr.innerHTML = `<td data-label="#">${x.id}</td><td data-label="Ảnh"><img src="${av}" alt="" style="width:32px;height:32px;object-fit:cover;border:1px solid #ddd;border-radius:6px" onerror="this.onerror=null;this.src='../upload/avatar/default.svg';"></td><td data-label="Tên">${x.ten}</td><td data-label="Giá điểm">${x.gia_diem}</td><td data-label="Tồn kho">${x.ton_kho}</td><td data-label="Trạng thái">${badge(x.dang_hoat_dong)}</td>
+    <td class="text-end stack-actions">
       <div class="d-flex flex-nowrap justify-content-end gap-2">
         <button class="btn btn-outline-primary rounded-pill px-3 py-2">Sửa</button>
         <button class="btn btn-outline-info rounded-pill px-3 py-2">Ảnh</button>
@@ -348,8 +348,8 @@ async function lNap(){ const j = await jfetch('../api/lop_hoc_quan_tri.php'); if
     // Gắn data cho dòng (lop_hoc)
     tr.dataset.id = x.id;
     tr.dataset.ten = x.ten;
-    tr.innerHTML = `<td>${x.id}</td><td>${x.ten}</td><td>${badge(x.dang_hoat_dong)}</td>
-    <td class="text-end">
+    tr.innerHTML = `<td data-label="#">${x.id}</td><td data-label="Tên">${x.ten}</td><td data-label="Trạng thái">${badge(x.dang_hoat_dong)}</td>
+    <td class="text-end stack-actions">
       <div class="d-flex flex-nowrap justify-content-end gap-2">
         <button class="btn btn-outline-primary rounded-pill px-3 py-2">Sửa</button>
         <button class="btn btn-outline-warning rounded-pill px-3 py-2">${x.dang_hoat_dong? 'Tắt':'Bật'}</button>

--- a/public/hoc_sinh_quan_ly.php
+++ b/public/hoc_sinh_quan_ly.php
@@ -40,10 +40,10 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
       <div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
         <h5 class="ribbon-title-modern">Thêm học sinh</h5>
         <div class="row g-2">
-          <div class="col-4"><input id="ma" class="form-control" placeholder="Mã (tùy chọn)"></div>
-          <div class="col-8"><input id="ho_ten" class="form-control" placeholder="Họ tên"></div>
-          <div class="col-6 mt-2"><input id="anh_dai_dien_url" class="form-control" placeholder="Ảnh đại diện URL"></div>
-          <div class="col-3 mt-2">
+          <div class="col-12 col-sm-4"><input id="ma" class="form-control" placeholder="Mã (tùy chọn)"></div>
+          <div class="col-12 col-sm-8"><input id="ho_ten" class="form-control" placeholder="Họ tên"></div>
+          <div class="col-12 col-sm-6 mt-2"><input id="anh_dai_dien_url" class="form-control" placeholder="Ảnh đại diện URL"></div>
+          <div class="col-6 col-sm-3 mt-2">
             <select id="gioi_tinh" class="form-select">
               <option value="">Giới tính...</option>
               <option value="NAM">Nam</option>
@@ -51,22 +51,22 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
               <option value="KHAC">Khác</option>
             </select>
           </div>
-          <div class="col-3 mt-2"><input id="ngay_sinh" type="text" class="form-control date-picker" placeholder="Ngày sinh" data-datepicker="1"></div>
+          <div class="col-6 col-sm-3 mt-2"><input id="ngay_sinh" type="text" class="form-control date-picker" placeholder="Ngày sinh" data-datepicker="1"></div>
         </div>
         <div class="mt-2"><button id="them" class="btn btn-primary">Thêm</button><span id="msg" class="ms-2 small text-muted"></span></div>
         <hr>
-        <div class="d-flex align-items-center gap-2">
-          <div class="me-auto" style="max-width:320px;">
+        <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2">
+          <div class="me-sm-auto" style="max-width:320px;">
             <label class="form-label">Nhập CSV</label>
             <div class="custom-file-input-sm position-relative">
               <input type="file" id="csv_file" accept=".csv" class="form-control form-control-sm" aria-label="Chọn file CSV">
               <span class="custom-file-label" id="csv_file_label">Chưa chọn tệp</span>
             </div>
           </div>
-          <div class="pt-4">
+          <div class="pt-sm-4">
             <div class="d-flex gap-2">
-              <button id="nhap_csv" class="btn btn-outline-primary btn-sm px-3">Nhập CSV</button>
-              <button id="xuat_csv" class="btn btn-outline-primary btn-sm px-3">Xuất CSV</button>
+              <button id="nhap_csv" class="btn btn-outline-primary btn-sm px-3 flex-fill">Nhập CSV</button>
+              <button id="xuat_csv" class="btn btn-outline-primary btn-sm px-3 flex-fill">Xuất CSV</button>
             </div>
           </div>
         </div>
@@ -82,18 +82,18 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
               <div class="small text-muted"><span id="ct_lop"></span> · <span id="ct_trang_thai"></span></div>
             </div>
           </div>
-          <div class="d-flex align-items-center gap-2 mt-2">
+          <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2 mt-2">
             <input type="file" id="up_anh" accept="image/*" class="form-control form-control-sm" style="max-width:320px">
             <button id="btn_up_anh" class="btn btn-outline-primary btn-sm">Upload ảnh</button>
             <button id="btn_toggle" class="btn btn-outline-warning btn-sm">Tắt</button>
           </div>
           <div id="ct_msg" class="small text-muted mt-1"></div>
           <div class="row g-2 mt-2">
-            <div class="col-4"><label class="form-label">Mã</label><input id="ct_ma" class="form-control"></div>
-            <div class="col-8"><label class="form-label">Họ tên</label><input id="ct_ho_ten" class="form-control"></div>
-            <div class="col-6"><label class="form-label">Lớp</label><select id="ct_lop" class="form-select"></select></div>
-            <div class="col-3"><label class="form-label">Giới tính</label><select id="ct_gioi" class="form-select"><option value="">--</option><option value="NAM">Nam</option><option value="NU">Nữ</option><option value="KHAC">Khác</option></select></div>
-            <div class="col-3"><label class="form-label">Ngày sinh</label><input id="ct_ngay" type="text" class="form-control date-picker" data-datepicker="1" placeholder="dd/mm/yyyy"></div>
+            <div class="col-12 col-sm-4"><label class="form-label">Mã</label><input id="ct_ma" class="form-control"></div>
+            <div class="col-12 col-sm-8"><label class="form-label">Họ tên</label><input id="ct_ho_ten" class="form-control"></div>
+            <div class="col-12 col-sm-6"><label class="form-label">Lớp</label><select id="ct_lop" class="form-select"></select></div>
+            <div class="col-6 col-sm-3"><label class="form-label">Giới tính</label><select id="ct_gioi" class="form-select"><option value="">--</option><option value="NAM">Nam</option><option value="NU">Nữ</option><option value="KHAC">Khác</option></select></div>
+            <div class="col-6 col-sm-3"><label class="form-label">Ngày sinh</label><input id="ct_ngay" type="text" class="form-control date-picker" data-datepicker="1" placeholder="dd/mm/yyyy"></div>
           </div>
           <div class="mt-2"><button id="btn_luu" class="btn btn-primary btn-sm">Lưu thay đổi</button></div>
         </div>

--- a/public/lich_su.php
+++ b/public/lich_su.php
@@ -52,7 +52,7 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
       </div>
     </div>
   </div></div>
-  <div class="table-responsive mt-3" data-aos="fade-up">
+  <div class="table-responsive table-responsive-stack mt-3" data-aos="fade-up">
     <table class="table table-sm align-middle">
       <thead><tr><th>Thời gian</th><th>Học sinh</th><th>Loại</th><th>Thay đổi</th><th>Số dư</th><th>Ghi chú</th></tr></thead>
       <tbody id="tb"></tbody>
@@ -157,7 +157,7 @@ function veTrang(){
     const loaiHtml = loaiBadge(row.loai);
     const deltaHtml = formatSignedHtml(row.bien_diem);
     const balanceHtml = `<span class="fw-semibold">${row.so_du_sau}</span>`;
-    tr.innerHTML=`<td>${dinDangDateTime(row.tao_luc)}</td><td>${row.ho_ten}</td><td>${loaiHtml}</td><td>${deltaHtml}</td><td>${balanceHtml}</td><td>${row.ghi_chu||''}</td>`;
+    tr.innerHTML=`<td data-label="Thời gian">${dinDangDateTime(row.tao_luc)}</td><td data-label="Học sinh">${row.ho_ten}</td><td data-label="Loại">${loaiHtml}</td><td data-label="Thay đổi">${deltaHtml}</td><td data-label="Số dư">${balanceHtml}</td><td data-label="Ghi chú">${row.ghi_chu||''}</td>`;
     tb.appendChild(tr);
   });
   pgInfo.textContent = total ? `Trang ${trang}/${totalPages} – hiển thị ${start+1}-${end} / ${total}` : 'Không có dữ liệu';

--- a/public/trang_chinh.php
+++ b/public/trang_chinh.php
@@ -31,7 +31,7 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
       <div id="ds_hs" class="list-group mt-2" style="max-height:300px;overflow:auto"></div>
     </div></div></div>
     <div class="col-md-6"><div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
-      <div class="d-flex align-items-center justify-content-between"><h5 class="ribbon-title-modern mb-0">Thông tin</h5><button id="btn_qua_da_doi" class="btn btn-outline-secondary px-3 py-2" disabled>Qu&#224; &#273;&#227; &#273;&#7893;i</button></div><div id="thong_tin" class="mb-2 text-muted"></div>
+      <div class="d-flex align-items-center justify-content-between flex-wrap gap-2"><h5 class="ribbon-title-modern mb-0">Thông tin</h5><button id="btn_qua_da_doi" class="btn btn-outline-secondary px-3 py-2" disabled>Qu&#224; &#273;&#227; &#273;&#7893;i</button></div><div id="thong_tin" class="mb-2 text-muted"></div>
       <h5 class="ribbon-title-modern mt-2">Lý do</h5>      <input id="ly_do_loc" class="form-control form-control-sm mb-2" placeholder="Lọc lý do...">
 <div id="ds_ly_do" class="d-flex flex-wrap gap-2"></div>
       <hr><div class="d-flex align-items-center justify-content-between">
@@ -52,7 +52,7 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
     </div></div></div>
   </div>
   <div class="card mt-3 shadow-sm" data-aos="fade-up"><div class="card-body">
-    <h5 class="ribbon-title-modern">Lịch sử gần đây</h5><div class="table-responsive"><table class="table table-sm table-hover table-striped align-middle modern-table">
+    <h5 class="ribbon-title-modern">Lịch sử gần đây</h5><div class="table-responsive table-responsive-stack"><table class="table table-sm table-hover table-striped align-middle modern-table">
       <thead><tr><th>Thời gian</th><th>Học sinh</th><th>Loại</th><th>Thay đổi</th><th>Số dư</th><th>Ghi chú</th></tr></thead>
       <tbody id="bang_lich_su"></tbody></table></div>
     <div class="d-flex align-items-center justify-content-between mt-2">
@@ -299,12 +299,12 @@ function renderLichSu(){
     const ghiChu = row.ghi_chu||'';
     const tr=document.createElement('tr');
     tr.innerHTML = `
-      <td class="text-muted small">${formatDateTime(row.tao_luc)}</td>
-      <td>${row.ho_ten||''}</td>
-      <td>${loaiHtml}</td>
-      <td>${deltaHtml}</td>
-      <td>${soDuHtml}</td>
-      <td class="cell-notes"><span class="truncate">${ghiChu}</span></td>`;
+      <td class="text-muted small" data-label="Thời gian">${formatDateTime(row.tao_luc)}</td>
+      <td data-label="Học sinh">${row.ho_ten||''}</td>
+      <td data-label="Loại">${loaiHtml}</td>
+      <td data-label="Thay đổi">${deltaHtml}</td>
+      <td data-label="Số dư">${soDuHtml}</td>
+      <td class="cell-notes" data-label="Ghi chú"><span class="truncate">${ghiChu}</span></td>`;
     tb.appendChild(tr);
   });
   const info=document.getElementById('ls_info'); if(info){ const from=total?start+1:0; const to=Math.min(start+rows.length,total); info.textContent=`Trang ${lsPage}/${totalPages} · ${from}-${to}/${total}`; }

--- a/public/vendor/theme.css
+++ b/public/vendor/theme.css
@@ -533,6 +533,120 @@ body.login-bg {
   padding-bottom: .35rem;
 }
 
+/* ===================== Mobile-first refinements ===================== */
+
+/* Bảng dạng thẻ (card) trên mobile: mỗi <tr> thành 1 thẻ, mỗi <td> hiện
+   nhãn (data-label) bên trái + giá trị bên phải, tránh cuộn ngang. */
+@media (max-width: 767.98px){
+  .table-responsive-stack table{ border: 0; }
+  .table-responsive-stack thead{
+    position: absolute;
+    width: 1px; height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+  .table-responsive-stack tbody,
+  .table-responsive-stack tr,
+  .table-responsive-stack td{
+    display: block;
+    width: 100%;
+  }
+  .table-responsive-stack tr{
+    margin-bottom: .6rem;
+    border: 1px solid #d7e1f5 !important;
+    border-radius: 12px;
+    padding: .5rem .75rem;
+    background: #fff !important;
+    box-shadow: 0 2px 6px rgba(17,40,90,.06);
+  }
+  .table-responsive-stack tr:last-child{ margin-bottom: 0; }
+  .table-responsive-stack td{
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+    padding: .4rem 0 !important;
+    border: 0 !important;
+    text-align: right;
+  }
+  .table-responsive-stack td:not(:last-child){
+    border-bottom: 1px dotted #e3e9f5 !important;
+  }
+  .table-responsive-stack td[data-label]::before{
+    content: attr(data-label);
+    font-weight: 700;
+    color: #5f6b85;
+    text-align: left;
+    flex-shrink: 0;
+  }
+  .table-responsive-stack td:not([data-label]){
+    justify-content: flex-end;
+  }
+  .table-responsive-stack td.stack-actions{
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: .5rem;
+    padding-top: .6rem !important;
+  }
+  .table-responsive-stack td.stack-actions > div{
+    flex-wrap: wrap !important;
+    justify-content: center !important;
+    width: 100%;
+  }
+  .table-responsive-stack td.stack-actions .btn{ flex: 1 1 auto; min-width: 72px; }
+
+  /* Ghi chú: nội dung dạng câu dài nên hiển thị full chiều rộng, căn trái,
+     không cắt chữ (khác các cột giá trị ngắn khác vẫn căn phải). */
+  .table-responsive-stack td[data-label="Ghi chú"]{
+    display: block;
+    text-align: left;
+  }
+  .table-responsive-stack td[data-label="Ghi chú"]::before{
+    display: block;
+    margin-bottom: .15rem;
+  }
+  .table-responsive-stack td[data-label="Ghi chú"] .truncate{
+    display: block;
+    max-width: none;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+}
+
+/* Chart canvases: chiều cao thấp hơn trên màn hình nhỏ để đỡ phải cuộn dài */
+.chart-box{ height: 260px; }
+.chart-box-lg{ height: 280px; }
+@media (max-width: 575.98px){
+  .chart-box{ height: 200px; }
+  .chart-box-lg{ height: 220px; }
+}
+
+/* Touch target: bảo đảm control nhỏ (btn-sm, input-sm, nav-link) vẫn đủ lớn
+   để bấm ngón tay trên màn hình cảm ứng nhỏ. */
+@media (max-width: 767.98px){
+  .btn-sm{
+    min-height: 40px;
+    padding-top: .5rem;
+    padding-bottom: .5rem;
+  }
+  .form-control:not(.form-control-sm),
+  .form-select:not(.form-select-sm){
+    min-height: 44px;
+  }
+  .form-control-sm,
+  .form-select-sm{
+    min-height: 38px;
+  }
+  .nav-square-link{
+    min-height: 40px;
+  }
+  .dp-cell{
+    padding: 9px 0;
+  }
+}
+
 /* Header demo */
 .demo-header-body {
   background: #f7f7fb;


### PR DESCRIPTION
- Add a reusable table-responsive-stack CSS pattern: on screens <768px,
  data tables render as stacked label/value cards instead of scrolling
  horizontally. Applied to the 4 data tables in the app (lich su, trang
  chinh recent history, and the 3 admin tables in cau hinh).
- Fix grid columns that ignored mobile (unprefixed col-4/col-8/col-3/col-6)
  in the add/edit student forms so fields stack full-width on phones and
  only go side-by-side from the sm breakpoint up.
- Ensure touch targets stay usable on small screens (btn-sm, form-control-sm,
  nav links, datepicker cells) via a mobile-only min-height bump.
- Give Chart.js canvases a shared chart-box/chart-box-lg height utility that
  shrinks on narrow screens instead of a fixed inline height.
- Add flex-wrap to a few header rows that could overflow/wrap awkwardly next
  to a sibling button or label on narrow screens, matching the pattern
  already used elsewhere in the app.

Verified with Playwright at 375px (no horizontal scroll on any page) and
1280px (desktop layout unchanged).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017QuUpoLeSK7eyxc6fTP1mz