### PR TITLE
Add mobile API token auth + idempotent point sync endpoints

### DIFF
--- a/api/.htaccess
+++ b/api/.htaccess
@@ -1,6 +1,11 @@
 # Mở lại quyền truy cập cho api/ (bị chặn mặc định bởi .htaccess ở gốc repo).
 Options -Indexes
 
+# Một số cấu hình Apache mặc định không chuyển header Authorization vào PHP
+# ($_SERVER['HTTP_AUTHORIZATION']) - cần bật tường minh để token API (app di động) hoạt động.
+# Directive lõi từ Apache 2.4.13, an toàn để khai báo không điều kiện.
+CGIPassAuth On
+
 <IfModule mod_authz_core.c>
   Require all granted
 </IfModule>

--- a/api/diem.php
+++ b/api/diem.php
@@ -8,18 +8,21 @@ $hanh_dong = $_GET['hanh_dong'] ?? '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $hanh_dong === 'cong') {
   yeu_cau_dang_nhap(); $gv_id = (int)$_SESSION['giao_vien_id']; $b = than_json();
   $hs_id = (int)($b['hoc_sinh_id'] ?? 0); $ly_do_id = (int)($b['ly_do_id'] ?? 0); $ghi_chu = trim($b['ghi_chu'] ?? '');
+  // client_action_id: khóa idempotency app di động gửi kèm khi đồng bộ giao dịch offline.
+  $client_action_id = isset($b['client_action_id']) ? trim((string)$b['client_action_id']) : null;
   if (!$hs_id || !$ly_do_id) json_phan_hoi(false, null, 'thieu_thong_tin');
   try {
-    $kq = cong_diem_giao_vien($pdo, $gv_id, $hs_id, $ly_do_id, $ghi_chu);
+    $kq = cong_diem_giao_vien($pdo, $gv_id, $hs_id, $ly_do_id, $ghi_chu, $client_action_id);
     json_phan_hoi(true, $kq);
   } catch (Exception $e) { json_phan_hoi(false, null, $e->getMessage()); }
 }
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $hanh_dong === 'quy_doi') {
   yeu_cau_dang_nhap(); $gv_id = (int)$_SESSION['giao_vien_id']; $b = than_json();
   $hs_id = (int)($b['hoc_sinh_id'] ?? 0); $qua_id = (int)($b['qua_tang_id'] ?? 0); $ghi_chu = trim($b['ghi_chu'] ?? '');
+  $client_action_id = isset($b['client_action_id']) ? trim((string)$b['client_action_id']) : null;
   if (!$hs_id || !$qua_id) json_phan_hoi(false, null, 'thieu_thong_tin');
   try {
-    $kq = quy_doi_qua_tang($pdo, $gv_id, $hs_id, $qua_id, $ghi_chu);
+    $kq = quy_doi_qua_tang($pdo, $gv_id, $hs_id, $qua_id, $ghi_chu, $client_action_id);
     json_phan_hoi(true, $kq);
   } catch (Exception $e) { json_phan_hoi(false, null, $e->getMessage()); }
 }

--- a/api/giao_vien_quan_tri.php
+++ b/api/giao_vien_quan_tri.php
@@ -16,7 +16,10 @@ if ($method === 'GET') {
   $st = $pdo->prepare("SELECT lop_hoc_id FROM giao_vien_lop WHERE giao_vien_id=?");
   $st->execute([$gv_id]);
   $ids = array_map(fn($r)=> (int)$r['lop_hoc_id'], $st->fetchAll());
-  json_phan_hoi(true, ['lop_hoc_ids' => $ids]);
+  $st2 = $pdo->prepare("SELECT api_token_bam FROM giao_vien WHERE id=?");
+  $st2->execute([$gv_id]);
+  $co_token = (bool)$st2->fetchColumn();
+  json_phan_hoi(true, ['lop_hoc_ids' => $ids, 'co_token_api' => $co_token]);
 }
 if ($method !== 'POST') { http_response_code(404); json_phan_hoi(false, null, 'khong_tim_thay'); }
 
@@ -35,6 +38,23 @@ if ($hanh_dong === 'doi_mat_khau') {
   $pdo->prepare('UPDATE giao_vien SET mat_khau_bam=?, phai_doi_mat_khau=0 WHERE id=?')->execute([$bam, (int)$gv['id']]);
   $_SESSION['phai_doi_mat_khau'] = false;
   ghi_log($pdo, $gv_id, 'doi_mat_khau', 'Đổi mật khẩu tài khoản '.$_SESSION['ten_dang_nhap']);
+  json_phan_hoi(true);
+}
+
+if ($hanh_dong === 'tao_token_api') {
+  // 1 token đang hoạt động/giáo viên (đơn giản hóa cho MVP app di động) - tạo mới sẽ thay thế
+  // token cũ, thiết bị đang dùng token cũ sẽ bị đăng xuất khỏi API. Chỉ trả token gốc lúc này,
+  // không lưu lại được nữa - chỉ lưu bản băm (sha256) trong CSDL.
+  $token = bin2hex(random_bytes(32));
+  $token_bam = hash('sha256', $token);
+  $pdo->prepare('UPDATE giao_vien SET api_token_bam=? WHERE id=?')->execute([$token_bam, $gv_id]);
+  ghi_log($pdo, $gv_id, 'tao_token_api', 'Tạo token API mới cho ứng dụng di động');
+  json_phan_hoi(true, ['token' => $token]);
+}
+
+if ($hanh_dong === 'thu_hoi_token_api') {
+  $pdo->prepare('UPDATE giao_vien SET api_token_bam=NULL WHERE id=?')->execute([$gv_id]);
+  ghi_log($pdo, $gv_id, 'thu_hoi_token_api', 'Thu hồi token API');
   json_phan_hoi(true);
 }
 

--- a/config/luoc_do.sql
+++ b/config/luoc_do.sql
@@ -10,6 +10,7 @@ CREATE TABLE giao_vien (
   mat_khau_bam TEXT NOT NULL,
   vai_tro TEXT DEFAULT 'GV',
   phai_doi_mat_khau INTEGER DEFAULT 0,
+  api_token_bam TEXT,
   tao_luc TEXT DEFAULT (datetime('now'))
 );
 CREATE TABLE giao_vien_lop (
@@ -70,8 +71,10 @@ CREATE TABLE so_cai_diem (
   bien_diem INTEGER NOT NULL,
   so_du_sau INTEGER NOT NULL,
   ghi_chu TEXT,
+  client_action_id TEXT,
   tao_luc TEXT DEFAULT (datetime('now')),
   FOREIGN KEY (hoc_sinh_id) REFERENCES hoc_sinh(id),
   FOREIGN KEY (giao_vien_id) REFERENCES giao_vien(id)
 );
 CREATE INDEX idx_so_cai_hoc_sinh_thoi_gian ON so_cai_diem(hoc_sinh_id, tao_luc);
+CREATE UNIQUE INDEX idx_so_cai_client_action_id ON so_cai_diem(client_action_id) WHERE client_action_id IS NOT NULL;

--- a/config/migration_nghiep_vu.php
+++ b/config/migration_nghiep_vu.php
@@ -29,8 +29,21 @@ if (!function_exists('chay_migration')) {
     ]);
     $ensureCols('giao_vien', [
       'vai_tro' => "vai_tro TEXT DEFAULT 'GV'",
-      'phai_doi_mat_khau' => 'phai_doi_mat_khau INTEGER DEFAULT 0'
+      'phai_doi_mat_khau' => 'phai_doi_mat_khau INTEGER DEFAULT 0',
+      // Token API cho app di động (offline-first): 1 token đang hoạt động/giáo viên, lưu dạng
+      // hash (sha256) - không lưu token gốc, chỉ hiển thị 1 lần lúc tạo.
+      'api_token_bam' => 'api_token_bam TEXT'
     ]);
+    // Khóa idempotency cho giao dịch đồng bộ từ app di động: app sinh 1 client_action_id ngẫu
+    // nhiên cho mỗi hành động cộng/đổi điểm trước khi có mạng; khi đồng bộ lại, nếu gửi trùng
+    // (do mất mạng giữa chừng, app retry) thì bỏ qua thay vì cộng/trừ điểm 2 lần.
+    $ensureCols('so_cai_diem', [
+      'client_action_id' => 'client_action_id TEXT'
+    ]);
+    try {
+      $pdo->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_so_cai_client_action_id
+                  ON so_cai_diem(client_action_id) WHERE client_action_id IS NOT NULL");
+    } catch (Throwable $e) { /* ignore */ }
     $ensureCols('qua_tang', [
       'anh_url' => 'anh_url TEXT',
       'nguoi_tao_id' => 'nguoi_tao_id INTEGER REFERENCES giao_vien(id) ON DELETE CASCADE'

--- a/lib/diem_nghiep_vu.php
+++ b/lib/diem_nghiep_vu.php
@@ -55,9 +55,25 @@ function doc_so_du(PDO $pdo, int $hoc_sinh_id): int
   return (int)$so_du;
 }
 
-function cong_diem_giao_vien(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int $ly_do_id, string $ghi_chu = ''): array
+/**
+ * Nếu client_action_id đã tồn tại (giao dịch này đã được áp dụng trước đó - app di động gửi lại
+ * do mất mạng giữa chừng khi đồng bộ), trả về kết quả cũ thay vì báo lỗi hoặc cộng/trừ điểm lần 2.
+ */
+function tim_giao_dich_da_ap_dung(PDO $pdo, string $client_action_id): ?array
+{
+  $st = $pdo->prepare('SELECT so_du_sau FROM so_cai_diem WHERE client_action_id = ?');
+  $st->execute([$client_action_id]);
+  $r = $st->fetch();
+  return $r ? ['so_du' => (int)$r['so_du_sau']] : null;
+}
+
+function cong_diem_giao_vien(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int $ly_do_id, string $ghi_chu = '', ?string $client_action_id = null): array
 {
   kiem_tra_quyen_lop($pdo, $giao_vien_id, $hoc_sinh_id);
+  if ($client_action_id !== null && $client_action_id !== '') {
+    $da_co = tim_giao_dich_da_ap_dung($pdo, $client_action_id);
+    if ($da_co !== null) { return $da_co; }
+  }
   $pdo->beginTransaction();
   try {
     dam_bao_vi($pdo, $hoc_sinh_id);
@@ -65,9 +81,9 @@ function cong_diem_giao_vien(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int 
     $stUp = $pdo->prepare('UPDATE vi_diem SET so_du = so_du + ? WHERE hoc_sinh_id = ?');
     $stUp->execute([$bien, $hoc_sinh_id]);
     $so_du_moi = doc_so_du($pdo, $hoc_sinh_id);
-    $pdo->prepare('INSERT INTO so_cai_diem(hoc_sinh_id, giao_vien_id, loai, ly_do_id, bien_diem, so_du_sau, ghi_chu)
-                   VALUES(?,?,?,?,?,?,?)')
-        ->execute([$hoc_sinh_id, $giao_vien_id, 'CONG_DIEM', $ly_do_id, $bien, $so_du_moi, $ghi_chu]);
+    $pdo->prepare('INSERT INTO so_cai_diem(hoc_sinh_id, giao_vien_id, loai, ly_do_id, bien_diem, so_du_sau, ghi_chu, client_action_id)
+                   VALUES(?,?,?,?,?,?,?,?)')
+        ->execute([$hoc_sinh_id, $giao_vien_id, 'CONG_DIEM', $ly_do_id, $bien, $so_du_moi, $ghi_chu, $client_action_id ?: null]);
     $pdo->commit();
     return ['so_du' => $so_du_moi];
   } catch (Throwable $e) {
@@ -78,9 +94,13 @@ function cong_diem_giao_vien(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int 
   }
 }
 
-function quy_doi_qua_tang(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int $qua_tang_id, string $ghi_chu = ''): array
+function quy_doi_qua_tang(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int $qua_tang_id, string $ghi_chu = '', ?string $client_action_id = null): array
 {
   kiem_tra_quyen_lop($pdo, $giao_vien_id, $hoc_sinh_id);
+  if ($client_action_id !== null && $client_action_id !== '') {
+    $da_co = tim_giao_dich_da_ap_dung($pdo, $client_action_id);
+    if ($da_co !== null) { return $da_co; }
+  }
   $st = $pdo->prepare('SELECT gia_diem, ton_kho FROM qua_tang WHERE id = ? AND dang_hoat_dong = 1 AND nguoi_tao_id = ?');
   $st->execute([$qua_tang_id, $giao_vien_id]);
   $q = $st->fetch();
@@ -106,9 +126,9 @@ function quy_doi_qua_tang(PDO $pdo, int $giao_vien_id, int $hoc_sinh_id, int $qu
     if ($ton > 0) {
       $pdo->prepare('UPDATE qua_tang SET ton_kho = ton_kho - 1 WHERE id = ?')->execute([$qua_tang_id]);
     }
-    $pdo->prepare('INSERT INTO so_cai_diem(hoc_sinh_id, giao_vien_id, loai, qua_tang_id, bien_diem, so_du_sau, ghi_chu)
-                   VALUES(?,?,?,?,?,?,?)')
-        ->execute([$hoc_sinh_id, $giao_vien_id, 'DOI_DIEM', $qua_tang_id, -$gia, $so_du_moi, $ghi_chu]);
+    $pdo->prepare('INSERT INTO so_cai_diem(hoc_sinh_id, giao_vien_id, loai, qua_tang_id, bien_diem, so_du_sau, ghi_chu, client_action_id)
+                   VALUES(?,?,?,?,?,?,?,?)')
+        ->execute([$hoc_sinh_id, $giao_vien_id, 'DOI_DIEM', $qua_tang_id, -$gia, $so_du_moi, $ghi_chu, $client_action_id ?: null]);
     $pdo->commit();
     return ['so_du' => $so_du_moi];
   } catch (Throwable $e) {

--- a/lib/tro_giup.php
+++ b/lib/tro_giup.php
@@ -5,7 +5,26 @@ function json_phan_hoi($ok, $du_lieu=null, $thong_bao='') {
   echo json_encode(['ok'=>$ok, 'du_lieu'=>$du_lieu, 'thong_bao'=>$thong_bao], JSON_UNESCAPED_UNICODE);
   exit;
 }
+/**
+ * Xác thực bằng token API (app di động offline-first) qua header Authorization: Bearer <token>.
+ * Không đụng tới cookie/session của trình duyệt - chỉ set $_SESSION['giao_vien_id'] trong bộ nhớ
+ * cho đúng request hiện tại (client không dùng cookie thì Set-Cookie phản hồi cũng bị bỏ qua).
+ */
+function thu_xac_thuc_bang_token(PDO $pdo): bool {
+  $hdr = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+  if (!preg_match('/^Bearer\s+([A-Za-z0-9]+)$/', trim($hdr), $m)) { return false; }
+  $token_bam = hash('sha256', $m[1]);
+  $st = $pdo->prepare('SELECT id, phai_doi_mat_khau FROM giao_vien WHERE api_token_bam = ?');
+  $st->execute([$token_bam]);
+  $gv = $st->fetch();
+  if (!$gv) { return false; }
+  $_SESSION['giao_vien_id'] = (int)$gv['id'];
+  $_SESSION['phai_doi_mat_khau'] = !empty($gv['phai_doi_mat_khau']);
+  return true;
+}
 function yeu_cau_dang_nhap() {
+  global $pdo;
+  if (!isset($_SESSION['giao_vien_id']) && isset($pdo)) { thu_xac_thuc_bang_token($pdo); }
   if (!isset($_SESSION['giao_vien_id'])) { http_response_code(401); json_phan_hoi(false, null, 'chua_dang_nhap'); }
   if (!empty($_SESSION['phai_doi_mat_khau'])) {
     $script = $_SERVER['SCRIPT_NAME'] ?? '';

--- a/public/cau_hinh.php
+++ b/public/cau_hinh.php
@@ -179,6 +179,25 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
                 </div>
               </div>
             </div>
+            <div class="col-md-6">
+              <div class="border rounded-3 p-3 h-100">
+                <h5 class="ribbon-title-modern mb-3">Token API (app di động)</h5>
+                <div class="small text-muted mb-2">Dùng để đăng nhập ứng dụng di động (chấm điểm ngoại tuyến, đồng bộ khi có mạng). Tạo token mới sẽ vô hiệu token cũ trên thiết bị khác.</div>
+                <div id="gv_token_trang_thai" class="small mb-2"></div>
+                <div id="gv_token_box" class="d-none alert alert-warning py-2 px-3 small mb-2">
+                  <div class="fw-semibold mb-1">Token mới (chỉ hiển thị 1 lần, hãy sao chép và lưu ngay):</div>
+                  <div class="d-flex align-items-center gap-2">
+                    <code id="gv_token_gia_tri" class="text-break flex-grow-1"></code>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" id="gv_token_copy">Sao chép</button>
+                  </div>
+                </div>
+                <div class="d-flex align-items-center gap-2 flex-wrap">
+                  <button class="btn btn-outline-primary btn-sm" id="gv_token_tao">Tạo token mới</button>
+                  <button class="btn btn-outline-danger btn-sm" id="gv_token_thu_hoi">Thu hồi token</button>
+                  <span id="gv_token_msg" class="small text-muted"></span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -616,6 +635,57 @@ function hsSyncLopSelectOnce(){
     }
     else { msg.textContent=j.thong_bao||'Lỗi'; }
   };
+})();
+
+// Token API cho app di động
+(function(){
+  const trangThai = document.getElementById('gv_token_trang_thai');
+  const box = document.getElementById('gv_token_box');
+  const gtEl = document.getElementById('gv_token_gia_tri');
+  const msg = document.getElementById('gv_token_msg');
+  const btnTao = document.getElementById('gv_token_tao');
+  const btnThuHoi = document.getElementById('gv_token_thu_hoi');
+  const btnCopy = document.getElementById('gv_token_copy');
+  if (!trangThai || !btnTao || !btnThuHoi) return;
+
+  function ve(coToken){
+    trangThai.innerHTML = coToken
+      ? '<span class="text-success fw-semibold">Đã có token đang hoạt động</span>'
+      : '<span class="text-muted">Chưa tạo token nào</span>';
+  }
+
+  async function napTrangThai(){
+    try {
+      const j = await jfetch('../api/giao_vien_quan_tri.php');
+      if (j.ok) ve(!!j.du_lieu.co_token_api);
+    } catch(_e){}
+  }
+
+  btnTao.onclick = async()=>{
+    msg.textContent=''; box.classList.add('d-none');
+    if (!confirm('Tạo token mới sẽ vô hiệu token cũ (nếu có) trên mọi thiết bị đang dùng. Tiếp tục?')) return;
+    const j = await jfetch('../api/giao_vien_quan_tri.php?hanh_dong=tao_token_api',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+    if (j.ok) {
+      gtEl.textContent = j.du_lieu.token;
+      box.classList.remove('d-none');
+      ve(true);
+    } else { msg.textContent = j.thong_bao || 'Lỗi'; }
+  };
+
+  btnThuHoi.onclick = async()=>{
+    msg.textContent='';
+    if (!confirm('Thu hồi token hiện tại? Ứng dụng di động đang dùng token này sẽ không đăng nhập được nữa.')) return;
+    const j = await jfetch('../api/giao_vien_quan_tri.php?hanh_dong=thu_hoi_token_api',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+    if (j.ok) { box.classList.add('d-none'); ve(false); msg.textContent='Đã thu hồi token'; }
+    else { msg.textContent = j.thong_bao || 'Lỗi'; }
+  };
+
+  if (btnCopy) btnCopy.onclick = async()=>{
+    try { await navigator.clipboard.writeText(gtEl.textContent||''); msg.textContent='Đã sao chép'; }
+    catch(_e){ msg.textContent='Không sao chép được, hãy chọn thủ công'; }
+  };
+
+  napTrangThai();
 })();
 
 // Popup nhập liệu (Bootstrap modal)

--- a/public/cau_hinh.php
+++ b/public/cau_hinh.php
@@ -2,6 +2,12 @@
 require __DIR__ . '/../config/db.php'; require __DIR__ . '/../lib/tro_giup.php';
 if (!isset($_SESSION['giao_vien_id'])) { header('Location: dang_nhap.php'); exit; }
 $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
+// URL gốc của api/ (cùng cấp public/ theo quy ước docroot của app) - dùng để nhúng vào mã QR
+// token cho app di động, để app biết kết nối vào server nào (hỗ trợ tự host ở domain bất kỳ).
+$scheme = dang_https() ? 'https' : 'http';
+$host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$goc_duong_dan = preg_replace('#/public/[^/]*$#', '', $_SERVER['SCRIPT_NAME'] ?? '/public/cau_hinh.php');
+$api_goc_url = $scheme . '://' . $host . $goc_duong_dan . '/api/';
 ?><!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cấu hình hệ thống</title>
 <link rel="stylesheet" href="vendor/bootswatch/bootstrap.min.css"><link rel="stylesheet" href="vendor/bootstrap-icons/bootstrap-icons.css"><link rel="stylesheet" href="vendor/aos/aos.css"><link rel="stylesheet" href="vendor/theme.css"><link rel="stylesheet" href="vendor/custom_file.css"><link rel="stylesheet" href="vendor/date_picker.css"><style>.ld-stepper .ld-stepper-btns{min-width:38px;height:100%;}.ld-stepper .ld-stepper-btns .btn{padding:4px 0;line-height:1;height:50%;border-radius:0;}.ld-stepper .ld-stepper-btns .btn:first-child{border-top-right-radius:.375rem;}.ld-stepper .ld-stepper-btns .btn:last-child{border-bottom-right-radius:.375rem;}.ld-bd-wrap{position:relative;}.ld-bd-wrap input{padding-left:24px;}#ld_bien_diem::-webkit-outer-spin-button,#ld_bien_diem::-webkit-inner-spin-button{-webkit-appearance:none;margin:0;}#ld_bien_diem{-moz-appearance:textfield;}.ld-bd-plus{position:absolute;left:10px;top:50%;transform:translateY(-50%);color:#0d6efd;font-weight:600;pointer-events:none;font-size:.95rem;}</style></head><body><?php include __DIR__ . '/_nav.php'; ?>
@@ -185,10 +191,16 @@ $can_doi_mk_bat_buoc = !empty($_SESSION['phai_doi_mat_khau']);
                 <div class="small text-muted mb-2">Dùng để đăng nhập ứng dụng di động (chấm điểm ngoại tuyến, đồng bộ khi có mạng). Tạo token mới sẽ vô hiệu token cũ trên thiết bị khác.</div>
                 <div id="gv_token_trang_thai" class="small mb-2"></div>
                 <div id="gv_token_box" class="d-none alert alert-warning py-2 px-3 small mb-2">
-                  <div class="fw-semibold mb-1">Token mới (chỉ hiển thị 1 lần, hãy sao chép và lưu ngay):</div>
-                  <div class="d-flex align-items-center gap-2">
-                    <code id="gv_token_gia_tri" class="text-break flex-grow-1"></code>
-                    <button type="button" class="btn btn-outline-secondary btn-sm" id="gv_token_copy">Sao chép</button>
+                  <div class="fw-semibold mb-1">Token mới (chỉ hiển thị 1 lần, hãy lưu ngay):</div>
+                  <div class="d-flex flex-column flex-sm-row align-items-center gap-3">
+                    <div id="gv_token_qr" class="bg-white p-2 rounded-3 border flex-shrink-0"></div>
+                    <div class="flex-grow-1 w-100">
+                      <div class="small text-muted mb-1">Mở app DClass trên điện thoại, chọn "Quét mã để đăng nhập" và quét mã này. Không quét được thì dùng token bên dưới:</div>
+                      <div class="d-flex align-items-center gap-2">
+                        <code id="gv_token_gia_tri" class="text-break flex-grow-1"></code>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" id="gv_token_copy">Sao chép</button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div class="d-flex align-items-center gap-2 flex-wrap">
@@ -641,17 +653,34 @@ function hsSyncLopSelectOnce(){
 (function(){
   const trangThai = document.getElementById('gv_token_trang_thai');
   const box = document.getElementById('gv_token_box');
+  const qrEl = document.getElementById('gv_token_qr');
   const gtEl = document.getElementById('gv_token_gia_tri');
   const msg = document.getElementById('gv_token_msg');
   const btnTao = document.getElementById('gv_token_tao');
   const btnThuHoi = document.getElementById('gv_token_thu_hoi');
   const btnCopy = document.getElementById('gv_token_copy');
+  const apiGocUrl = <?php echo json_encode($api_goc_url, JSON_UNESCAPED_SLASHES); ?>;
   if (!trangThai || !btnTao || !btnThuHoi) return;
 
   function ve(coToken){
     trangThai.innerHTML = coToken
       ? '<span class="text-success fw-semibold">Đã có token đang hoạt động</span>'
       : '<span class="text-muted">Chưa tạo token nào</span>';
+  }
+
+  function veQr(token){
+    if (!qrEl) return;
+    qrEl.innerHTML = '';
+    if (typeof qrcode === 'undefined') return; // thư viện lỗi tải thì vẫn còn token chữ để dùng
+    // Payload gồm cả token lẫn địa chỉ server, để app di động biết kết nối vào đâu (hỗ trợ tự host).
+    const payload = JSON.stringify({ token: token, api_url: apiGocUrl });
+    // typeNumber=0: tự chọn phiên bản QR nhỏ nhất vừa đủ chứa payload.
+    const qr = qrcode(0, 'M');
+    qr.addData(payload);
+    qr.make();
+    qrEl.innerHTML = qr.createSvgTag({ scalable: true });
+    const svg = qrEl.querySelector('svg');
+    if (svg) { svg.style.width = '160px'; svg.style.height = '160px'; svg.style.display = 'block'; }
   }
 
   async function napTrangThai(){
@@ -667,6 +696,7 @@ function hsSyncLopSelectOnce(){
     const j = await jfetch('../api/giao_vien_quan_tri.php?hanh_dong=tao_token_api',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
     if (j.ok) {
       gtEl.textContent = j.du_lieu.token;
+      veQr(j.du_lieu.token);
       box.classList.remove('d-none');
       ve(true);
     } else { msg.textContent = j.thong_bao || 'Lỗi'; }
@@ -782,6 +812,7 @@ ldNap(); qNap(); lNap();
 <script src="vendor/bootstrap/bootstrap.bundle.min.js"></script>
 <script src="vendor/aos/aos.js"></script>
 <script src="vendor/date_picker.js"></script>
+<script src="vendor/qrcode/qrcode.js"></script>
 <script>AOS.init({ duration: 350, once: true, easing: 'ease-out' });</script>
 </body></html>
 

--- a/public/vendor/qrcode/LICENSE
+++ b/public/vendor/qrcode/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2009 Kazuhiko Arase
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+Vendored from https://github.com/kazuhikoarase/qrcode-generator (npm package
+"qrcode-generator" v2.0.4, file dist/qrcode.js) for offline QR code rendering
+in DClass - no code changes made.

--- a/public/vendor/qrcode/qrcode.js
+++ b/public/vendor/qrcode/qrcode.js
@@ -1,0 +1,2297 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+      define([], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory();
+  }
+}(function () {
+    return qrcode;
+}));

--- a/tests/DiemTest.php
+++ b/tests/DiemTest.php
@@ -85,6 +85,49 @@ final class DiemTest extends TestCase
     cong_diem_giao_vien($pdo, $gv_id, $hs_id, $ly_do_id, 'thu');
   }
 
+  public function testCongDiemVoiClientActionIdTrungKhongCongDupLan2(): void
+  {
+    $pdo = tao_pdo_test();
+    $gv_id = chen_giao_vien($pdo);
+    $lop_id = chen_lop($pdo, '4A');
+    $hs_id = chen_hoc_sinh($pdo, 'HS 1', $lop_id);
+    $ly_do_id = chen_ly_do($pdo, 'Cham chi', 2, $gv_id);
+    gan_giao_vien_vao_lop($pdo, $gv_id, $lop_id);
+
+    $client_action_id = 'phone-action-abc-123';
+    $lan_1 = cong_diem_giao_vien($pdo, $gv_id, $hs_id, $ly_do_id, 'thu nghiem', $client_action_id);
+    // Mô phỏng app di động gửi lại đúng hành động này (mất mạng giữa chừng khi đồng bộ, retry).
+    $lan_2 = cong_diem_giao_vien($pdo, $gv_id, $hs_id, $ly_do_id, 'thu nghiem', $client_action_id);
+
+    $this->assertSame(2, $lan_1['so_du']);
+    $this->assertSame(2, $lan_2['so_du']);
+    $st = $pdo->query('SELECT COUNT(*) FROM so_cai_diem WHERE loai="CONG_DIEM"');
+    $this->assertSame(1, (int)$st->fetchColumn());
+  }
+
+  public function testQuyDoiVoiClientActionIdTrungKhongTruDupLan2(): void
+  {
+    $pdo = tao_pdo_test();
+    $gv_id = chen_giao_vien($pdo);
+    $lop_id = chen_lop($pdo, '4A');
+    $hs_id = chen_hoc_sinh($pdo, 'HS 1', $lop_id);
+    $qua_id = chen_qua($pdo, 'Sticker', 3, 5, $gv_id);
+    gan_giao_vien_vao_lop($pdo, $gv_id, $lop_id);
+    $pdo->prepare('INSERT INTO vi_diem(hoc_sinh_id, so_du) VALUES(?, ?)')->execute([$hs_id, 10]);
+
+    $client_action_id = 'phone-action-doi-qua-1';
+    $lan_1 = quy_doi_qua_tang($pdo, $gv_id, $hs_id, $qua_id, 'doi qua', $client_action_id);
+    $lan_2 = quy_doi_qua_tang($pdo, $gv_id, $hs_id, $qua_id, 'doi qua', $client_action_id);
+
+    $this->assertSame(7, $lan_1['so_du']);
+    $this->assertSame(7, $lan_2['so_du']);
+    $st = $pdo->prepare('SELECT ton_kho FROM qua_tang WHERE id = ?');
+    $st->execute([$qua_id]);
+    $this->assertSame(4, (int)$st->fetchColumn());
+    $st = $pdo->query('SELECT COUNT(*) FROM so_cai_diem WHERE loai="DOI_DIEM"');
+    $this->assertSame(1, (int)$st->fetchColumn());
+  }
+
   public function testKiemTraDangNhapThanhCongVaThatBai(): void
   {
     $pdo = tao_pdo_test();

--- a/tests/TokenApiTest.php
+++ b/tests/TokenApiTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class TokenApiTest extends TestCase
+{
+  protected function tearDown(): void
+  {
+    unset($_SERVER['HTTP_AUTHORIZATION'], $_SESSION['giao_vien_id'], $_SESSION['phai_doi_mat_khau']);
+  }
+
+  public function testXacThucThanhCongVoiTokenDung(): void
+  {
+    $pdo = tao_pdo_test();
+    $gv_id = chen_giao_vien($pdo);
+    $token = bin2hex(random_bytes(32));
+    $pdo->prepare('UPDATE giao_vien SET api_token_bam=? WHERE id=?')->execute([hash('sha256', $token), $gv_id]);
+
+    $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+    $ket_qua = thu_xac_thuc_bang_token($pdo);
+
+    $this->assertTrue($ket_qua);
+    $this->assertSame($gv_id, $_SESSION['giao_vien_id']);
+  }
+
+  public function testXacThucThatBaiVoiTokenSai(): void
+  {
+    $pdo = tao_pdo_test();
+    $gv_id = chen_giao_vien($pdo);
+    $pdo->prepare('UPDATE giao_vien SET api_token_bam=? WHERE id=?')->execute([hash('sha256', 'token-that'), $gv_id]);
+
+    $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer token-sai-hoan-toan';
+    $ket_qua = thu_xac_thuc_bang_token($pdo);
+
+    $this->assertFalse($ket_qua);
+    $this->assertArrayNotHasKey('giao_vien_id', $_SESSION);
+  }
+
+  public function testXacThucThatBaiKhiKhongCoHeader(): void
+  {
+    $pdo = tao_pdo_test();
+    chen_giao_vien($pdo);
+
+    $ket_qua = thu_xac_thuc_bang_token($pdo);
+
+    $this->assertFalse($ket_qua);
+  }
+
+  public function testThuHoiTokenLamMatHieuLucXacThuc(): void
+  {
+    $pdo = tao_pdo_test();
+    $gv_id = chen_giao_vien($pdo);
+    $token = bin2hex(random_bytes(32));
+    $pdo->prepare('UPDATE giao_vien SET api_token_bam=? WHERE id=?')->execute([hash('sha256', $token), $gv_id]);
+    // Thu hồi token (như hanh_dong=thu_hoi_token_api trong api/giao_vien_quan_tri.php)
+    $pdo->prepare('UPDATE giao_vien SET api_token_bam=NULL WHERE id=?')->execute([$gv_id]);
+
+    $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+    $ket_qua = thu_xac_thuc_bang_token($pdo);
+
+    $this->assertFalse($ket_qua);
+  }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,7 @@ if (file_exists($autoload)) {
 require_once __DIR__ . '/../lib/diem_nghiep_vu.php';
 require_once __DIR__ . '/../lib/dang_nhap_nghiep_vu.php';
 require_once __DIR__ . '/../lib/hoc_sinh_nghiep_vu.php';
+require_once __DIR__ . '/../lib/tro_giup.php';
 require_once __DIR__ . '/../config/migration_nghiep_vu.php';
 
 function tao_pdo_test(): PDO


### PR DESCRIPTION
## Summary

Backend groundwork for the planned offline-first Flutter app discussed on this branch's earlier PRs: web stays the source of truth (admin, reports, CSV, setup), the mobile app only needs to add/redeem points fast while offline and push a queue of actions back when it regains connectivity. This PR adds the two small, additive pieces the mobile app needs — no new endpoints, no rewrite of existing logic — plus a QR-based login flow since a 64-char hex token is painful for non-technical teachers to copy/paste.

- **Bearer token auth**: `yeu_cau_dang_nhap()` now also accepts `Authorization: Bearer <token>` alongside the existing session cookie. A teacher generates/revokes their token from `cau_hinh.php`'s "Tài khoản" tab (`api/giao_vien_quan_tri.php?hanh_dong=tao_token_api` / `thu_hoi_token_api`) — shown once, stored only as a sha256 hash. One active token per teacher for now (generating a new one invalidates the previous one) — simplest thing that works for a single phone; can extend to multiple named tokens later if actually needed.
- **Idempotent point transactions**: `cong_diem_giao_vien()` / `quy_doi_qua_tang()` take an optional `client_action_id`, stored on `so_cai_diem` behind a partial unique index. A phone that queues point actions offline and retries a push after a dropped connection won't double-apply the same transaction — this is the outbox/replay sync pattern discussed for the mobile app, and it maps directly onto `so_cai_diem` since it's already an append-only ledger.
- The mobile app doesn't need any new read endpoints — it reuses `api/hoc_sinh.php`, `api/ly_do.php`, `api/qua_tang.php` (GET) and `api/diem.php` (POST) exactly as they are today, just authenticated with a token instead of a cookie.
- Added `CGIPassAuth On` to `api/.htaccess` since some Apache configs strip the `Authorization` header before it reaches PHP.
- **QR code login**: the token box on `cau_hinh.php` now also renders a QR code encoding `{"token":..., "api_url":...}` — scan-to-login instead of copy-pasting a 64-character string. `api_url` is computed server-side from the request so self-hosted instances at any domain work. Vendored `kazuhikoarase/qrcode-generator` (MIT, single file, zero deps) into `public/vendor/qrcode/` to keep this fully client-side/offline, consistent with the rest of the app's assets. The raw token stays visible underneath as a fallback for when scanning isn't possible.

## Test plan
- [x] `php scripts/lint.php` — no syntax errors on any changed file.
- [x] End-to-end over the real PHP built-in server (not just unit-level): registered a teacher, generated a token via session, then made Bearer-token-only requests (no cookies) — listed students, added points, and **retried the exact same `client_action_id`** — confirmed identical `so_du` in the response and only 1 row in `so_cai_diem` (checked directly in the DB). Missing/wrong/revoked token all return 401.
- [x] Verified the new columns (`giao_vien.api_token_bam`, `so_cai_diem.client_action_id`) backfill correctly via `chay_migration()` starting from a pre-upgrade schema (the same scenario `MigrationBackfillTest.php` exercises), and that point-adding still works normally afterward.
- [x] Confirmed calling `cong_diem_giao_vien()`/`quy_doi_qua_tang()` without a `client_action_id` (i.e. every existing call site in the web UI) behaves exactly as before — `NULL` values never collide under the partial unique index, so normal web usage is unaffected.
- [x] QR flow verified with Playwright + OpenCV's QR decoder: generated a token through the real UI, decoded the rendered QR image, confirmed the payload matches the displayed token and `api_url` resolves to the right server, and confirmed the decoded token actually authenticates against `api/hoc_sinh.php`.
- [ ] Added `tests/TokenApiTest.php` and 2 new cases in `tests/DiemTest.php`, but PHPUnit isn't installable in this sandbox (`composer install` can't authenticate against GitHub when running as root). The same logic was verified manually by calling the exact same helper functions from `tests/bootstrap.php` outside of PHPUnit (see test plan above) — should still run these in CI to get proper coverage confirmation.

## Not in scope here
The Flutter app itself, the pull-sync of reference data (students/reasons/gifts) down to the app on first login and reconnect, and the client-side outbox/queue logic — this PR is only the backend pieces + QR login the mobile app depends on.
