### PR TITLE
Scaffold Flutter mobile app (dclass_mobile)

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,43 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.pub-cache/
+.pub/
+/build/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,57 @@
+# dclass_mobile
+
+Offline-first companion app for teachers: fast in-class point add/redeem from
+a phone. The web app (`public/`) stays the source of truth for admin,
+reports, and setup (students, classes, reasons, gifts) - this app only needs
+to read that data and push point transactions.
+
+It talks to the existing JSON API (`api/hoc_sinh.php`, `api/ly_do.php`,
+`api/qua_tang.php`, `api/diem.php`) using the Bearer token auth added in
+[#81](../../../pull/81): generate a token from **Cấu hình > Tài khoản** on
+the web app (shown once as text and a QR code), paste it into the app's
+login screen along with the server URL.
+
+## What's here
+
+This folder currently has only the Dart side of a Flutter project
+(`pubspec.yaml`, `lib/`, `test/`) - there's no Flutter SDK in this sandbox to
+run `flutter create`, so the platform folders (`android/`, `ios/`, `web/`,
+etc.) haven't been generated yet.
+
+To finish scaffolding on a machine with Flutter installed:
+
+```bash
+cd mobile
+flutter create --org com.dclass --project-name dclass_mobile .
+```
+
+`flutter create .` on a directory that already has a `pubspec.yaml`/`lib/`
+fills in the missing platform folders; it may also rewrite
+`pubspec.yaml`/`analysis_options.yaml`/`test/widget_test.dart` with its own
+template. Run `git status`/`git diff` afterwards and re-apply anything from
+this version worth keeping (dependencies, lint rule, the login-screen test)
+before committing.
+
+Then:
+
+```bash
+flutter pub get
+flutter run
+```
+
+## Structure
+
+- `lib/api_client.dart` - HTTP client wrapping the Bearer-token API, including
+  `client_action_id` support for idempotent point transactions (safe to
+  retry after a dropped connection).
+- `lib/models/` - `HocSinh`, `LyDo`, `QuaTang` matching the JSON shapes those
+  endpoints already return.
+- `lib/screens/login_screen.dart` - enter server URL + token, verified with a
+  real API call before saving (via `shared_preferences`).
+- `lib/screens/students_screen.dart` - student list with a per-row "add
+  points" action.
+
+Not yet implemented: an offline outbox/replay queue (queuing actions while
+offline and syncing them back with retried `client_action_id`s once
+connectivity returns) - the backend supports it, but the app currently
+requires a live connection for every action.

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_single_quotes: true

--- a/mobile/lib/api_client.dart
+++ b/mobile/lib/api_client.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import 'models/hoc_sinh.dart';
+import 'models/ly_do.dart';
+import 'models/qua_tang.dart';
+
+/// Thrown when the DClass API responds with `ok: false`, or with a
+/// non-2xx HTTP status.
+class ApiException implements Exception {
+  final String thongBao;
+  ApiException(this.thongBao);
+
+  @override
+  String toString() => thongBao;
+}
+
+/// Thin client for the DClass teacher-facing JSON API (api/*.php), using the
+/// Bearer token auth added for the mobile app (see api/dang_nhap.php and
+/// lib/tro_giup.php::thu_xac_thuc_bang_token).
+class ApiClient {
+  final String baseUrl;
+  final String token;
+
+  ApiClient({required this.baseUrl, required this.token});
+
+  Uri _uri(String path, [Map<String, String>? query]) {
+    return Uri.parse('$baseUrl$path').replace(queryParameters: query);
+  }
+
+  Map<String, String> get _headers => {
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      };
+
+  dynamic _giaiMa(http.Response res) {
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw ApiException('loi_http_${res.statusCode}');
+    }
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    if (body['ok'] != true) {
+      throw ApiException((body['thong_bao'] as String?) ?? 'loi_khong_xac_dinh');
+    }
+    return body['du_lieu'];
+  }
+
+  Future<List<HocSinh>> danhSachHocSinh({int? lopHocId, String tuKhoa = ''}) async {
+    final query = <String, String>{};
+    if (lopHocId != null) query['lop_hoc_id'] = '$lopHocId';
+    if (tuKhoa.isNotEmpty) query['tu_khoa'] = tuKhoa;
+    final res = await http.get(_uri('/api/hoc_sinh.php', query), headers: _headers);
+    final data = _giaiMa(res) as List<dynamic>;
+    return data.map((e) => HocSinh.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<List<LyDo>> danhSachLyDo() async {
+    final res = await http.get(_uri('/api/ly_do.php'), headers: _headers);
+    final data = _giaiMa(res) as List<dynamic>;
+    return data.map((e) => LyDo.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  Future<List<QuaTang>> danhSachQuaTang() async {
+    final res = await http.get(_uri('/api/qua_tang.php'), headers: _headers);
+    final data = _giaiMa(res) as List<dynamic>;
+    return data.map((e) => QuaTang.fromJson(e as Map<String, dynamic>)).toList();
+  }
+
+  /// [clientActionId] should be a stable id (e.g. a uuid generated once per
+  /// offline action) so a retried sync after a dropped connection doesn't
+  /// double-apply the same transaction. See so_cai_diem.client_action_id.
+  Future<Map<String, dynamic>> congDiem({
+    required int hocSinhId,
+    required int lyDoId,
+    String ghiChu = '',
+    String? clientActionId,
+  }) async {
+    final res = await http.post(
+      _uri('/api/diem.php', {'hanh_dong': 'cong'}),
+      headers: _headers,
+      body: jsonEncode({
+        'hoc_sinh_id': hocSinhId,
+        'ly_do_id': lyDoId,
+        'ghi_chu': ghiChu,
+        if (clientActionId != null) 'client_action_id': clientActionId,
+      }),
+    );
+    return _giaiMa(res) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> quyDoiQuaTang({
+    required int hocSinhId,
+    required int quaTangId,
+    String ghiChu = '',
+    String? clientActionId,
+  }) async {
+    final res = await http.post(
+      _uri('/api/diem.php', {'hanh_dong': 'quy_doi'}),
+      headers: _headers,
+      body: jsonEncode({
+        'hoc_sinh_id': hocSinhId,
+        'qua_tang_id': quaTangId,
+        'ghi_chu': ghiChu,
+        if (clientActionId != null) 'client_action_id': clientActionId,
+      }),
+    );
+    return _giaiMa(res) as Map<String, dynamic>;
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'api_client.dart';
+import 'screens/login_screen.dart';
+import 'screens/students_screen.dart';
+
+const String prefsBaseUrl = 'base_url';
+const String prefsToken = 'api_token';
+
+void main() {
+  runApp(const DClassApp());
+}
+
+class DClassApp extends StatelessWidget {
+  const DClassApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'DClass',
+      theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
+      home: const _KhoiDong(),
+    );
+  }
+}
+
+/// Reads any saved base URL/token and routes straight to the student list,
+/// otherwise falls back to the login screen.
+class _KhoiDong extends StatefulWidget {
+  const _KhoiDong();
+
+  @override
+  State<_KhoiDong> createState() => _KhoiDongState();
+}
+
+class _KhoiDongState extends State<_KhoiDong> {
+  ApiClient? _client;
+  bool _dangTai = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _nap();
+  }
+
+  Future<void> _nap() async {
+    final prefs = await SharedPreferences.getInstance();
+    final baseUrl = prefs.getString(prefsBaseUrl);
+    final token = prefs.getString(prefsToken);
+    setState(() {
+      _client = (baseUrl != null && token != null)
+          ? ApiClient(baseUrl: baseUrl, token: token)
+          : null;
+      _dangTai = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dangTai) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    return _client == null
+        ? const LoginScreen()
+        : StudentsScreen(client: _client!);
+  }
+}

--- a/mobile/lib/models/hoc_sinh.dart
+++ b/mobile/lib/models/hoc_sinh.dart
@@ -1,0 +1,28 @@
+class HocSinh {
+  final int id;
+  final String? ma;
+  final String hoTen;
+  final int? lopHocId;
+  final String? tenLop;
+  final int soDu;
+
+  HocSinh({
+    required this.id,
+    required this.ma,
+    required this.hoTen,
+    required this.lopHocId,
+    required this.tenLop,
+    required this.soDu,
+  });
+
+  factory HocSinh.fromJson(Map<String, dynamic> json) {
+    return HocSinh(
+      id: json['id'] as int,
+      ma: json['ma'] as String?,
+      hoTen: json['ho_ten'] as String? ?? '',
+      lopHocId: json['lop_hoc_id'] as int?,
+      tenLop: json['ten_lop'] as String?,
+      soDu: (json['so_du'] as num?)?.toInt() ?? 0,
+    );
+  }
+}

--- a/mobile/lib/models/ly_do.dart
+++ b/mobile/lib/models/ly_do.dart
@@ -1,0 +1,15 @@
+class LyDo {
+  final int id;
+  final String tieuDe;
+  final int bienDiem;
+
+  LyDo({required this.id, required this.tieuDe, required this.bienDiem});
+
+  factory LyDo.fromJson(Map<String, dynamic> json) {
+    return LyDo(
+      id: json['id'] as int,
+      tieuDe: json['tieu_de'] as String? ?? '',
+      bienDiem: (json['bien_diem'] as num?)?.toInt() ?? 0,
+    );
+  }
+}

--- a/mobile/lib/models/qua_tang.dart
+++ b/mobile/lib/models/qua_tang.dart
@@ -1,0 +1,25 @@
+class QuaTang {
+  final int id;
+  final String ten;
+  final int giaDiem;
+  final int tonKho;
+  final String? anhUrl;
+
+  QuaTang({
+    required this.id,
+    required this.ten,
+    required this.giaDiem,
+    required this.tonKho,
+    required this.anhUrl,
+  });
+
+  factory QuaTang.fromJson(Map<String, dynamic> json) {
+    return QuaTang(
+      id: json['id'] as int,
+      ten: json['ten'] as String? ?? '',
+      giaDiem: (json['gia_diem'] as num?)?.toInt() ?? 0,
+      tonKho: (json['ton_kho'] as num?)?.toInt() ?? 0,
+      anhUrl: json['anh_url'] as String?,
+    );
+  }
+}

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../api_client.dart';
+import '../main.dart';
+import 'students_screen.dart';
+
+/// Lets a teacher point the app at their DClass server and paste the API
+/// token generated from cau_hinh.php's "Tài khoản" tab (shown there as text
+/// and a QR code).
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _urlCtrl = TextEditingController(text: 'https://');
+  final _tokenCtrl = TextEditingController();
+  bool _dangKetNoi = false;
+  String? _loi;
+
+  @override
+  void dispose() {
+    _urlCtrl.dispose();
+    _tokenCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _dangNhap() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _dangKetNoi = true;
+      _loi = null;
+    });
+    final baseUrl = _urlCtrl.text.trim().replaceAll(RegExp(r'/+$'), '');
+    final token = _tokenCtrl.text.trim();
+    final client = ApiClient(baseUrl: baseUrl, token: token);
+    try {
+      await client.danhSachHocSinh();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(prefsBaseUrl, baseUrl);
+      await prefs.setString(prefsToken, token);
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => StudentsScreen(client: client)),
+      );
+    } catch (e) {
+      setState(() => _loi = 'Không kết nối được: $e');
+    } finally {
+      if (mounted) setState(() => _dangKetNoi = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Kết nối DClass')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _urlCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Địa chỉ server',
+                  hintText: 'https://truong-cua-ban.vn',
+                ),
+                keyboardType: TextInputType.url,
+                validator: (v) =>
+                    (v == null || v.trim().length < 8) ? 'Nhập địa chỉ hợp lệ' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _tokenCtrl,
+                decoration: const InputDecoration(
+                  labelText: 'Token API',
+                  hintText: 'Lấy trong Cấu hình > Tài khoản',
+                ),
+                obscureText: true,
+                validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập token' : null,
+              ),
+              const SizedBox(height: 24),
+              if (_loi != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Text(_loi!, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+                ),
+              FilledButton(
+                onPressed: _dangKetNoi ? null : _dangNhap,
+                child: _dangKetNoi
+                    ? const SizedBox(
+                        height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Text('Kết nối'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -1,0 +1,118 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../api_client.dart';
+import '../models/hoc_sinh.dart';
+import '../models/ly_do.dart';
+
+/// Student list with a quick "add points" action per row - the core
+/// in-class flow the mobile app exists for (web stays the tool for
+/// admin/reports/setup).
+class StudentsScreen extends StatefulWidget {
+  final ApiClient client;
+  const StudentsScreen({super.key, required this.client});
+
+  @override
+  State<StudentsScreen> createState() => _StudentsScreenState();
+}
+
+class _StudentsScreenState extends State<StudentsScreen> {
+  late Future<List<HocSinh>> _hocSinh;
+
+  @override
+  void initState() {
+    super.initState();
+    _hocSinh = widget.client.danhSachHocSinh();
+  }
+
+  Future<void> _lamMoi() async {
+    setState(() => _hocSinh = widget.client.danhSachHocSinh());
+    await _hocSinh;
+  }
+
+  String _taoClientActionId() {
+    final r = Random();
+    return '${DateTime.now().microsecondsSinceEpoch}-${r.nextInt(1 << 32)}';
+  }
+
+  Future<void> _chonLyDoVaCongDiem(HocSinh hs) async {
+    List<LyDo> lyDoList;
+    try {
+      lyDoList = await widget.client.danhSachLyDo();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Lỗi tải lý do: $e')));
+      return;
+    }
+    if (!mounted) return;
+    final lyDo = await showModalBottomSheet<LyDo>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: lyDoList
+              .map((ld) => ListTile(
+                    title: Text(ld.tieuDe),
+                    trailing: Text(ld.bienDiem > 0 ? '+${ld.bienDiem}' : '${ld.bienDiem}'),
+                    onTap: () => Navigator.of(ctx).pop(ld),
+                  ))
+              .toList(),
+        ),
+      ),
+    );
+    if (lyDo == null) return;
+    try {
+      await widget.client.congDiem(
+        hocSinhId: hs.id,
+        lyDoId: lyDo.id,
+        clientActionId: _taoClientActionId(),
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Đã cộng điểm cho ${hs.hoTen}')));
+      await _lamMoi();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Lỗi: $e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Học sinh')),
+      body: RefreshIndicator(
+        onRefresh: _lamMoi,
+        child: FutureBuilder<List<HocSinh>>(
+          future: _hocSinh,
+          builder: (context, snap) {
+            if (snap.connectionState != ConnectionState.done) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (snap.hasError) {
+              return Center(child: Text('Lỗi: ${snap.error}'));
+            }
+            final list = snap.data ?? [];
+            if (list.isEmpty) {
+              return const Center(child: Text('Chưa có học sinh nào'));
+            }
+            return ListView.separated(
+              itemCount: list.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, i) {
+                final hs = list[i];
+                return ListTile(
+                  title: Text(hs.hoTen),
+                  subtitle: Text(hs.tenLop ?? ''),
+                  trailing: Text('${hs.soDu} điểm'),
+                  onTap: () => _chonLyDoVaCongDiem(hs),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,0 +1,21 @@
+name: dclass_mobile
+description: "DClass mobile companion app - fast in-class point add/redeem for teachers."
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.0
+  shared_preferences: ^2.2.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dclass_mobile/main.dart';
+
+void main() {
+  testWidgets('shows the login screen when no token is saved', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const DClassApp());
+    await tester.pump();
+    expect(find.text('Kết nối DClass'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `mobile/` — a Dart-side Flutter scaffold for the offline-first teacher companion app that the mobile API token auth in #81 was groundwork for.
- `lib/api_client.dart` wraps the existing `api/hoc_sinh.php`, `api/ly_do.php`, `api/qua_tang.php`, `api/diem.php` JSON API with Bearer-token auth, including `client_action_id` for idempotent point transactions.
- `lib/screens/login_screen.dart` (server URL + token, verified with a live API call before saving) and `lib/screens/students_screen.dart` (student list with a quick add-points action) are the two screens.
- No Flutter SDK was available in this environment, so only `lib/`, `pubspec.yaml`, and `test/` exist — platform folders (`android/`, `ios/`, `web/`, etc.) still need `flutter create .` on a machine with Flutter installed. See `mobile/README.md` for the exact steps.

## Test plan
- [ ] Run `flutter create --org com.dclass --project-name dclass_mobile .` inside `mobile/` on a machine with the Flutter SDK, then review `git diff` for anything it overwrote (pubspec.yaml, analysis_options.yaml, test/widget_test.dart) and re-apply this version's deps/lints/test as needed
- [ ] `flutter pub get`
- [ ] `flutter test` (widget test expects the login screen when no token is saved)
- [ ] `flutter run`, log in with a token generated from Cấu hình > Tài khoản, confirm student list loads and adding points updates the balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)