### PR TITLE
Add Flutter CI and PR auto-labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+flutter:
+  - changed-files:
+      - any-glob-to-any-file: 'mobile/**'
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'api/**'
+          - 'lib/**'
+          - 'config/**'
+          - 'public/**'
+          - 'tests/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'

--- a/.github/workflows/ci-flutter.yml
+++ b/.github/workflows/ci-flutter.yml
@@ -33,7 +33,9 @@ jobs:
         run: flutter pub get
 
       - name: Format check
-        run: dart format --output=none --set-exit-if-changed .
+        run: |
+          dart format .
+          git diff --exit-code
 
       - name: Analyze (lint)
         run: flutter analyze

--- a/.github/workflows/ci-flutter.yml
+++ b/.github/workflows/ci-flutter.yml
@@ -1,0 +1,42 @@
+name: CI Flutter (mobile)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/ci-flutter.yml'
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/ci-flutter.yml'
+
+defaults:
+  run:
+    working-directory: mobile
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Format check
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze (lint)
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/mobile/lib/api_client.dart
+++ b/mobile/lib/api_client.dart
@@ -29,9 +29,9 @@ class ApiClient {
   }
 
   Map<String, String> get _headers => {
-        'Authorization': 'Bearer $token',
-        'Content-Type': 'application/json',
-      };
+    'Authorization': 'Bearer $token',
+    'Content-Type': 'application/json',
+  };
 
   dynamic _giaiMa(http.Response res) {
     if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -39,18 +39,28 @@ class ApiClient {
     }
     final body = jsonDecode(res.body) as Map<String, dynamic>;
     if (body['ok'] != true) {
-      throw ApiException((body['thong_bao'] as String?) ?? 'loi_khong_xac_dinh');
+      throw ApiException(
+        (body['thong_bao'] as String?) ?? 'loi_khong_xac_dinh',
+      );
     }
     return body['du_lieu'];
   }
 
-  Future<List<HocSinh>> danhSachHocSinh({int? lopHocId, String tuKhoa = ''}) async {
+  Future<List<HocSinh>> danhSachHocSinh({
+    int? lopHocId,
+    String tuKhoa = '',
+  }) async {
     final query = <String, String>{};
     if (lopHocId != null) query['lop_hoc_id'] = '$lopHocId';
     if (tuKhoa.isNotEmpty) query['tu_khoa'] = tuKhoa;
-    final res = await http.get(_uri('/api/hoc_sinh.php', query), headers: _headers);
+    final res = await http.get(
+      _uri('/api/hoc_sinh.php', query),
+      headers: _headers,
+    );
     final data = _giaiMa(res) as List<dynamic>;
-    return data.map((e) => HocSinh.fromJson(e as Map<String, dynamic>)).toList();
+    return data
+        .map((e) => HocSinh.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 
   Future<List<LyDo>> danhSachLyDo() async {
@@ -62,7 +72,9 @@ class ApiClient {
   Future<List<QuaTang>> danhSachQuaTang() async {
     final res = await http.get(_uri('/api/qua_tang.php'), headers: _headers);
     final data = _giaiMa(res) as List<dynamic>;
-    return data.map((e) => QuaTang.fromJson(e as Map<String, dynamic>)).toList();
+    return data
+        .map((e) => QuaTang.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 
   /// [clientActionId] should be a stable id (e.g. a uuid generated once per

--- a/mobile/lib/api_client.dart
+++ b/mobile/lib/api_client.dart
@@ -29,9 +29,9 @@ class ApiClient {
   }
 
   Map<String, String> get _headers => {
-    'Authorization': 'Bearer $token',
-    'Content-Type': 'application/json',
-  };
+        'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      };
 
   dynamic _giaiMa(http.Response res) {
     if (res.statusCode < 200 || res.statusCode >= 300) {

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -73,8 +73,9 @@ class _LoginScreenState extends State<LoginScreen> {
                   hintText: 'https://truong-cua-ban.vn',
                 ),
                 keyboardType: TextInputType.url,
-                validator: (v) =>
-                    (v == null || v.trim().length < 8) ? 'Nhập địa chỉ hợp lệ' : null,
+                validator: (v) => (v == null || v.trim().length < 8)
+                    ? 'Nhập địa chỉ hợp lệ'
+                    : null,
               ),
               const SizedBox(height: 16),
               TextFormField(
@@ -84,19 +85,28 @@ class _LoginScreenState extends State<LoginScreen> {
                   hintText: 'Lấy trong Cấu hình > Tài khoản',
                 ),
                 obscureText: true,
-                validator: (v) => (v == null || v.trim().isEmpty) ? 'Nhập token' : null,
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? 'Nhập token' : null,
               ),
               const SizedBox(height: 24),
               if (_loi != null)
                 Padding(
                   padding: const EdgeInsets.only(bottom: 16),
-                  child: Text(_loi!, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+                  child: Text(
+                    _loi!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
                 ),
               FilledButton(
                 onPressed: _dangKetNoi ? null : _dangNhap,
                 child: _dangKetNoi
                     ? const SizedBox(
-                        height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
                     : const Text('Kết nối'),
               ),
             ],

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -42,7 +42,9 @@ class _StudentsScreenState extends State<StudentsScreen> {
       lyDoList = await widget.client.danhSachLyDo();
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Lỗi tải lý do: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Lỗi tải lý do: $e')));
       return;
     }
     if (!mounted) return;
@@ -52,11 +54,15 @@ class _StudentsScreenState extends State<StudentsScreen> {
         child: ListView(
           shrinkWrap: true,
           children: lyDoList
-              .map((ld) => ListTile(
-                    title: Text(ld.tieuDe),
-                    trailing: Text(ld.bienDiem > 0 ? '+${ld.bienDiem}' : '${ld.bienDiem}'),
-                    onTap: () => Navigator.of(ctx).pop(ld),
-                  ))
+              .map(
+                (ld) => ListTile(
+                  title: Text(ld.tieuDe),
+                  trailing: Text(
+                    ld.bienDiem > 0 ? '+${ld.bienDiem}' : '${ld.bienDiem}',
+                  ),
+                  onTap: () => Navigator.of(ctx).pop(ld),
+                ),
+              )
               .toList(),
         ),
       ),
@@ -69,12 +75,15 @@ class _StudentsScreenState extends State<StudentsScreen> {
         clientActionId: _taoClientActionId(),
       );
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Đã cộng điểm cho ${hs.hoTen}')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Đã cộng điểm cho ${hs.hoTen}')));
       await _lamMoi();
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Lỗi: $e')));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Lỗi: $e')));
     }
   }
 


### PR DESCRIPTION
## Summary
- `.github/workflows/ci-flutter.yml` — triggers on changes under `mobile/**`: `flutter pub get`, `dart format --set-exit-if-changed`, `flutter analyze`, `flutter test` (covers both unit and widget tests), on `ubuntu-latest`.
- `.github/workflows/labeler.yml` + `.github/labeler.yml` — labels PRs by changed path (`flutter`, `backend`, `documentation`, `ci`) via `actions/labeler@v5`. Added the `flutter`/`backend`/`ci` labels to the repo so the labeler can actually apply them (`documentation` already existed).
- `dart format mobile/lib` — three files in the mobile scaffold (merged in #82) weren't in the standard Dart format the new CI step now enforces; reformatted them so the new format-check job passes.

## Test plan
- [ ] Confirm the `CI Flutter (mobile)` workflow runs on this PR and passes (format/analyze/test)
- [ ] Confirm this PR gets auto-labeled `flutter` + `ci` (it touches both `mobile/` and `.github/`)
- [ ] On a follow-up PR touching only `mobile/**`, confirm it's labeled `flutter` and the Flutter CI job runs; confirm a PHP-only PR does *not* trigger the Flutter CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)