### PR TITLE
mobile: Phase 0 foundation for offline+sync layer

### DIFF
--- a/.github/workflows/ci-flutter.yml
+++ b/.github/workflows/ci-flutter.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Analyze (lint)
         run: flutter analyze
 
+      - name: Ensure libsqlite3 is present (sqflite_common_ffi needs it for tests)
+        run: sudo apt-get update -y && sudo apt-get install -y libsqlite3-0
+
       - name: Run tests
         run: flutter test

--- a/mobile/lib/api_client.dart
+++ b/mobile/lib/api_client.dart
@@ -69,6 +69,7 @@ class ApiClient implements DiemApi {
     return body['du_lieu'];
   }
 
+  @override
   Future<List<HocSinh>> danhSachHocSinh({
     int? lopHocId,
     String tuKhoa = '',
@@ -86,12 +87,14 @@ class ApiClient implements DiemApi {
         .toList();
   }
 
+  @override
   Future<List<LyDo>> danhSachLyDo() async {
     final res = await http.get(_uri('/api/ly_do.php'), headers: _headers);
     final data = _giaiMa(res) as List<dynamic>;
     return data.map((e) => LyDo.fromJson(e as Map<String, dynamic>)).toList();
   }
 
+  @override
   Future<List<QuaTang>> danhSachQuaTang() async {
     final res = await http.get(_uri('/api/qua_tang.php'), headers: _headers);
     final data = _giaiMa(res) as List<dynamic>;
@@ -103,6 +106,7 @@ class ApiClient implements DiemApi {
   /// [clientActionId] should be a stable id (e.g. a uuid generated once per
   /// offline action) so a retried sync after a dropped connection doesn't
   /// double-apply the same transaction. See so_cai_diem.client_action_id.
+  @override
   Future<Map<String, dynamic>> congDiem({
     required int hocSinhId,
     required int lyDoId,
@@ -122,6 +126,7 @@ class ApiClient implements DiemApi {
     return _giaiMa(res) as Map<String, dynamic>;
   }
 
+  @override
   Future<Map<String, dynamic>> quyDoiQuaTang({
     required int hocSinhId,
     required int quaTangId,

--- a/mobile/lib/api_client.dart
+++ b/mobile/lib/api_client.dart
@@ -15,10 +15,33 @@ class ApiException implements Exception {
   String toString() => thongBao;
 }
 
+/// Contract for the DClass teacher-facing JSON API, extracted so tests (the
+/// sync engine and repositories) can depend on this instead of [ApiClient]
+/// directly and substitute a fake with scripted responses/exceptions.
+abstract class DiemApi {
+  Future<List<HocSinh>> danhSachHocSinh({int? lopHocId, String tuKhoa = ''});
+  Future<List<LyDo>> danhSachLyDo();
+  Future<List<QuaTang>> danhSachQuaTang();
+
+  Future<Map<String, dynamic>> congDiem({
+    required int hocSinhId,
+    required int lyDoId,
+    String ghiChu = '',
+    String? clientActionId,
+  });
+
+  Future<Map<String, dynamic>> quyDoiQuaTang({
+    required int hocSinhId,
+    required int quaTangId,
+    String ghiChu = '',
+    String? clientActionId,
+  });
+}
+
 /// Thin client for the DClass teacher-facing JSON API (api/*.php), using the
 /// Bearer token auth added for the mobile app (see api/dang_nhap.php and
 /// lib/tro_giup.php::thu_xac_thuc_bang_token).
-class ApiClient {
+class ApiClient implements DiemApi {
   final String baseUrl;
   final String token;
 

--- a/mobile/lib/db/app_database.dart
+++ b/mobile/lib/db/app_database.dart
@@ -52,12 +52,17 @@ CREATE INDEX idx_hang_doi_trang_thai ON hang_doi_thao_tac(trang_thai);
 ///
 /// [path] overrides the on-device storage location - tests pass
 /// `inMemoryDatabasePath` (from `sqflite_common_ffi`) to get an isolated
-/// in-memory database per test instead of touching disk.
+/// in-memory database per test instead of touching disk. `singleInstance` is
+/// forced off whenever [path] is given: sqflite otherwise caches connections
+/// by path, and every test using the same literal `:memory:` constant would
+/// share one leftover database instead of each getting a fresh one.
 Future<Database> openAppDatabase({String? path}) async {
+  final laDuongDanTuyChinh = path != null;
   final duongDan = path ?? p.join(await getDatabasesPath(), 'dclass_mobile.db');
   return openDatabase(
     duongDan,
     version: schemaVersion,
+    singleInstance: !laDuongDanTuyChinh,
     onCreate: (db, version) async {
       for (final cauLenh in _taoBang.split(';')) {
         final sql = cauLenh.trim();

--- a/mobile/lib/db/app_database.dart
+++ b/mobile/lib/db/app_database.dart
@@ -1,0 +1,70 @@
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart';
+
+const int schemaVersion = 1;
+
+const String _taoBang = '''
+CREATE TABLE hoc_sinh_cache (
+  id INTEGER PRIMARY KEY,
+  ma TEXT,
+  ho_ten TEXT NOT NULL,
+  lop_hoc_id INTEGER,
+  ten_lop TEXT,
+  so_du_may_chu INTEGER NOT NULL DEFAULT 0,
+  cap_nhat_luc TEXT
+);
+
+CREATE TABLE ly_do_cache (
+  id INTEGER PRIMARY KEY,
+  tieu_de TEXT NOT NULL,
+  bien_diem INTEGER NOT NULL,
+  cap_nhat_luc TEXT
+);
+
+CREATE TABLE qua_tang_cache (
+  id INTEGER PRIMARY KEY,
+  ten TEXT NOT NULL,
+  gia_diem INTEGER NOT NULL,
+  ton_kho_may_chu INTEGER NOT NULL DEFAULT 0,
+  anh_url TEXT,
+  cap_nhat_luc TEXT
+);
+
+CREATE TABLE hang_doi_thao_tac (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  client_action_id TEXT NOT NULL UNIQUE,
+  loai TEXT NOT NULL CHECK(loai IN ('CONG_DIEM','DOI_DIEM')),
+  hoc_sinh_id INTEGER NOT NULL,
+  ly_do_id INTEGER,
+  qua_tang_id INTEGER,
+  ghi_chu TEXT,
+  trang_thai TEXT NOT NULL DEFAULT 'cho_xu_ly'
+    CHECK(trang_thai IN ('cho_xu_ly','dang_gui','loi_vinh_vien')),
+  loi_ma TEXT,
+  so_lan_thu INTEGER NOT NULL DEFAULT 0,
+  tao_luc TEXT NOT NULL,
+  cap_nhat_luc TEXT
+);
+CREATE INDEX idx_hang_doi_trang_thai ON hang_doi_thao_tac(trang_thai);
+''';
+
+/// Opens (creating if needed) the app's local cache + outbox database.
+///
+/// [path] overrides the on-device storage location - tests pass
+/// `inMemoryDatabasePath` (from `sqflite_common_ffi`) to get an isolated
+/// in-memory database per test instead of touching disk.
+Future<Database> openAppDatabase({String? path}) async {
+  final duongDan = path ?? p.join(await getDatabasesPath(), 'dclass_mobile.db');
+  return openDatabase(
+    duongDan,
+    version: schemaVersion,
+    onCreate: (db, version) async {
+      for (final cauLenh in _taoBang.split(';')) {
+        final sql = cauLenh.trim();
+        if (sql.isNotEmpty) {
+          await db.execute(sql);
+        }
+      }
+    },
+  );
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -11,11 +11,17 @@ dependencies:
     sdk: flutter
   http: ^1.2.0
   shared_preferences: ^2.2.0
+  flutter_secure_storage: ^9.0.0
+  sqflite: ^2.3.0
+  path: ^1.9.0
+  uuid: ^4.4.0
+  connectivity_plus: ^6.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  sqflite_common_ffi: ^2.3.0
 
 flutter:
   uses-material-design: true

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -1,0 +1,13 @@
+import 'dart:async';
+
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+/// Flutter automatically wraps every test file's `main()` in this - it's the
+/// one place to point `sqflite` at the FFI backend (real SQLite via native
+/// bindings, no platform channel) so `flutter test` can exercise the local
+/// database without a device or emulator.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+  return testMain();
+}


### PR DESCRIPTION
## Summary
Phase 0 of the approved offline+sync plan (see plan context in-thread) — no user-visible behavior change, just the foundation the later phases build on:
- `mobile/lib/db/app_database.dart` — local sqflite schema: read-model caches for students/reasons/gifts (`hoc_sinh_cache`, `ly_do_cache`, `qua_tang_cache`) plus an outbox table (`hang_doi_thao_tac`) for queued point actions, ordered by local autoincrement `id` for strict FIFO replay.
- `api_client.dart` — extract a `DiemApi` interface (`ApiClient implements DiemApi`) so the sync engine/repositories in later phases can depend on the interface and tests can substitute a fake. No behavior change.
- `mobile/test/flutter_test_config.dart` — wires `sqflite_common_ffi` so `flutter test` can exercise real SQLite against the new schema with no device/emulator.
- `pubspec.yaml` — add `sqflite`, `sqflite_common_ffi` (dev), `path`, `uuid`, `connectivity_plus`, `flutter_secure_storage` for the phases that follow.
- `ci-flutter.yml` — install `libsqlite3-0` before running tests (defensive; usually already present on `ubuntu-latest`).

## Test plan
- [ ] `CI Flutter (mobile)` passes: `flutter pub get` resolves the new dependencies cleanly, `dart format`/`flutter analyze` pass, `flutter test` runs (no tests exercise the new schema yet — that starts in Phase 1/2 — this PR just confirms the plumbing doesn't break anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)