### PR TITLE
mobile: Phase 1 read-side caching (DanhMucRepository)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'api_client.dart';
+import 'db/app_database.dart';
+import 'repositories/danh_muc_repository.dart';
 import 'screens/login_screen.dart';
 import 'screens/students_screen.dart';
 
@@ -36,6 +38,7 @@ class _KhoiDong extends StatefulWidget {
 
 class _KhoiDongState extends State<_KhoiDong> {
   ApiClient? _client;
+  DanhMucRepository? _danhMuc;
   bool _dangTai = true;
 
   @override
@@ -48,10 +51,15 @@ class _KhoiDongState extends State<_KhoiDong> {
     final prefs = await SharedPreferences.getInstance();
     final baseUrl = prefs.getString(prefsBaseUrl);
     final token = prefs.getString(prefsToken);
+    if (baseUrl == null || token == null) {
+      setState(() => _dangTai = false);
+      return;
+    }
+    final client = ApiClient(baseUrl: baseUrl, token: token);
+    final db = await openAppDatabase();
     setState(() {
-      _client = (baseUrl != null && token != null)
-          ? ApiClient(baseUrl: baseUrl, token: token)
-          : null;
+      _client = client;
+      _danhMuc = DanhMucRepository(api: client, db: db);
       _dangTai = false;
     });
   }
@@ -61,8 +69,8 @@ class _KhoiDongState extends State<_KhoiDong> {
     if (_dangTai) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    return _client == null
+    return (_client == null || _danhMuc == null)
         ? const LoginScreen()
-        : StudentsScreen(client: _client!);
+        : StudentsScreen(client: _client!, danhMuc: _danhMuc!);
   }
 }

--- a/mobile/lib/models/hoc_sinh.dart
+++ b/mobile/lib/models/hoc_sinh.dart
@@ -25,4 +25,28 @@ class HocSinh {
       soDu: (json['so_du'] as num?)?.toInt() ?? 0,
     );
   }
+
+  /// Row shape for `hoc_sinh_cache` (see `lib/db/app_database.dart`).
+  factory HocSinh.fromCacheRow(Map<String, Object?> row) {
+    return HocSinh(
+      id: row['id'] as int,
+      ma: row['ma'] as String?,
+      hoTen: row['ho_ten'] as String? ?? '',
+      lopHocId: row['lop_hoc_id'] as int?,
+      tenLop: row['ten_lop'] as String?,
+      soDu: (row['so_du_may_chu'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, Object?> toCacheRow() {
+    return {
+      'id': id,
+      'ma': ma,
+      'ho_ten': hoTen,
+      'lop_hoc_id': lopHocId,
+      'ten_lop': tenLop,
+      'so_du_may_chu': soDu,
+      'cap_nhat_luc': DateTime.now().toIso8601String(),
+    };
+  }
 }

--- a/mobile/lib/models/ly_do.dart
+++ b/mobile/lib/models/ly_do.dart
@@ -12,4 +12,22 @@ class LyDo {
       bienDiem: (json['bien_diem'] as num?)?.toInt() ?? 0,
     );
   }
+
+  /// Row shape for `ly_do_cache` (see `lib/db/app_database.dart`).
+  factory LyDo.fromCacheRow(Map<String, Object?> row) {
+    return LyDo(
+      id: row['id'] as int,
+      tieuDe: row['tieu_de'] as String? ?? '',
+      bienDiem: (row['bien_diem'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, Object?> toCacheRow() {
+    return {
+      'id': id,
+      'tieu_de': tieuDe,
+      'bien_diem': bienDiem,
+      'cap_nhat_luc': DateTime.now().toIso8601String(),
+    };
+  }
 }

--- a/mobile/lib/models/qua_tang.dart
+++ b/mobile/lib/models/qua_tang.dart
@@ -22,4 +22,26 @@ class QuaTang {
       anhUrl: json['anh_url'] as String?,
     );
   }
+
+  /// Row shape for `qua_tang_cache` (see `lib/db/app_database.dart`).
+  factory QuaTang.fromCacheRow(Map<String, Object?> row) {
+    return QuaTang(
+      id: row['id'] as int,
+      ten: row['ten'] as String? ?? '',
+      giaDiem: (row['gia_diem'] as num?)?.toInt() ?? 0,
+      tonKho: (row['ton_kho_may_chu'] as num?)?.toInt() ?? 0,
+      anhUrl: row['anh_url'] as String?,
+    );
+  }
+
+  Map<String, Object?> toCacheRow() {
+    return {
+      'id': id,
+      'ten': ten,
+      'gia_diem': giaDiem,
+      'ton_kho_may_chu': tonKho,
+      'anh_url': anhUrl,
+      'cap_nhat_luc': DateTime.now().toIso8601String(),
+    };
+  }
 }

--- a/mobile/lib/repositories/danh_muc_repository.dart
+++ b/mobile/lib/repositories/danh_muc_repository.dart
@@ -1,0 +1,64 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../api_client.dart';
+import '../models/hoc_sinh.dart';
+import '../models/ly_do.dart';
+import '../models/qua_tang.dart';
+
+/// Caches the reference data a teacher needs (students, reasons, gifts) so
+/// the app keeps working with no connection. Strategy: try the network
+/// first - it's the freshest data, and refreshes the cache for next time -
+/// and fall back to whatever was last synced when the network call fails.
+class DanhMucRepository {
+  DanhMucRepository({required this.api, required this.db});
+  final DiemApi api;
+  final Database db;
+
+  Future<List<HocSinh>> danhSachHocSinh() async {
+    try {
+      final ds = await api.danhSachHocSinh();
+      await db.transaction((txn) async {
+        await txn.delete('hoc_sinh_cache');
+        for (final hs in ds) {
+          await txn.insert('hoc_sinh_cache', hs.toCacheRow());
+        }
+      });
+      return ds;
+    } catch (_) {
+      final rows = await db.query('hoc_sinh_cache', orderBy: 'ho_ten ASC');
+      return rows.map(HocSinh.fromCacheRow).toList();
+    }
+  }
+
+  Future<List<LyDo>> danhSachLyDo() async {
+    try {
+      final ds = await api.danhSachLyDo();
+      await db.transaction((txn) async {
+        await txn.delete('ly_do_cache');
+        for (final ld in ds) {
+          await txn.insert('ly_do_cache', ld.toCacheRow());
+        }
+      });
+      return ds;
+    } catch (_) {
+      final rows = await db.query('ly_do_cache', orderBy: 'bien_diem DESC');
+      return rows.map(LyDo.fromCacheRow).toList();
+    }
+  }
+
+  Future<List<QuaTang>> danhSachQuaTang() async {
+    try {
+      final ds = await api.danhSachQuaTang();
+      await db.transaction((txn) async {
+        await txn.delete('qua_tang_cache');
+        for (final qt in ds) {
+          await txn.insert('qua_tang_cache', qt.toCacheRow());
+        }
+      });
+      return ds;
+    } catch (_) {
+      final rows = await db.query('qua_tang_cache', orderBy: 'gia_diem ASC');
+      return rows.map(QuaTang.fromCacheRow).toList();
+    }
+  }
+}

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../api_client.dart';
+import '../db/app_database.dart';
 import '../main.dart';
+import '../repositories/danh_muc_repository.dart';
 import 'students_screen.dart';
 
 /// Lets a teacher point the app at their DClass server and paste the API
@@ -43,9 +45,13 @@ class _LoginScreenState extends State<LoginScreen> {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(prefsBaseUrl, baseUrl);
       await prefs.setString(prefsToken, token);
+      final db = await openAppDatabase();
+      final danhMuc = DanhMucRepository(api: client, db: db);
       if (!mounted) return;
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => StudentsScreen(client: client)),
+        MaterialPageRoute(
+          builder: (_) => StudentsScreen(client: client, danhMuc: danhMuc),
+        ),
       );
     } catch (e) {
       setState(() => _loi = 'Không kết nối được: $e');

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -5,13 +5,19 @@ import 'package:flutter/material.dart';
 import '../api_client.dart';
 import '../models/hoc_sinh.dart';
 import '../models/ly_do.dart';
+import '../repositories/danh_muc_repository.dart';
 
 /// Student list with a quick "add points" action per row - the core
 /// in-class flow the mobile app exists for (web stays the tool for
 /// admin/reports/setup).
 class StudentsScreen extends StatefulWidget {
   final ApiClient client;
-  const StudentsScreen({super.key, required this.client});
+  final DanhMucRepository danhMuc;
+  const StudentsScreen({
+    super.key,
+    required this.client,
+    required this.danhMuc,
+  });
 
   @override
   State<StudentsScreen> createState() => _StudentsScreenState();
@@ -23,11 +29,11 @@ class _StudentsScreenState extends State<StudentsScreen> {
   @override
   void initState() {
     super.initState();
-    _hocSinh = widget.client.danhSachHocSinh();
+    _hocSinh = widget.danhMuc.danhSachHocSinh();
   }
 
   Future<void> _lamMoi() async {
-    setState(() => _hocSinh = widget.client.danhSachHocSinh());
+    setState(() => _hocSinh = widget.danhMuc.danhSachHocSinh());
     await _hocSinh;
   }
 
@@ -39,7 +45,7 @@ class _StudentsScreenState extends State<StudentsScreen> {
   Future<void> _chonLyDoVaCongDiem(HocSinh hs) async {
     List<LyDo> lyDoList;
     try {
-      lyDoList = await widget.client.danhSachLyDo();
+      lyDoList = await widget.danhMuc.danhSachLyDo();
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(

--- a/mobile/test/danh_muc_repository_test.dart
+++ b/mobile/test/danh_muc_repository_test.dart
@@ -1,0 +1,112 @@
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/models/hoc_sinh.dart';
+import 'package:dclass_mobile/models/ly_do.dart';
+import 'package:dclass_mobile/repositories/danh_muc_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'fakes/fake_diem_api.dart';
+
+void main() {
+  late FakeDiemApi api;
+  late DanhMucRepository repo;
+
+  setUp(() async {
+    api = FakeDiemApi();
+    final db = await openAppDatabase(path: inMemoryDatabasePath);
+    repo = DanhMucRepository(api: api, db: db);
+  });
+
+  test('online: returns fresh data and upserts the cache', () async {
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 1,
+        ma: 'HS1',
+        hoTen: 'An',
+        lopHocId: 1,
+        tenLop: '1A',
+        soDu: 5,
+      ),
+    ];
+
+    final ds = await repo.danhSachHocSinh();
+
+    expect(ds, hasLength(1));
+    expect(ds.single.hoTen, 'An');
+
+    // Cache was upserted - the next offline call should still see it.
+    api.loiHocSinh = Exception('mat_ket_noi');
+    final tuCache = await repo.danhSachHocSinh();
+    expect(tuCache, hasLength(1));
+    expect(tuCache.single.hoTen, 'An');
+  });
+
+  test('offline: falls back to the last-synced cache', () async {
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 1,
+        ma: null,
+        hoTen: 'Binh',
+        lopHocId: null,
+        tenLop: null,
+        soDu: 10,
+      ),
+    ];
+    await repo.danhSachHocSinh(); // seeds the cache while "online"
+
+    api.loiHocSinh = Exception('mat_ket_noi');
+    final ds = await repo.danhSachHocSinh();
+
+    expect(ds, hasLength(1));
+    expect(ds.single.hoTen, 'Binh');
+    expect(ds.single.soDu, 10);
+  });
+
+  test(
+    'offline with an empty cache returns an empty list, not a throw',
+    () async {
+      api.loiHocSinh = Exception('mat_ket_noi');
+      final ds = await repo.danhSachHocSinh();
+      expect(ds, isEmpty);
+    },
+  );
+
+  test('a fresh fetch fully replaces the cache (no stale leftovers)', () async {
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 1,
+        ma: null,
+        hoTen: 'Cu',
+        lopHocId: null,
+        tenLop: null,
+        soDu: 0,
+      ),
+    ];
+    await repo.danhSachHocSinh();
+
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 2,
+        ma: null,
+        hoTen: 'Danh',
+        lopHocId: null,
+        tenLop: null,
+        soDu: 0,
+      ),
+    ];
+    await repo.danhSachHocSinh();
+
+    api.loiHocSinh = Exception('mat_ket_noi');
+    final ds = await repo.danhSachHocSinh();
+    expect(ds.map((e) => e.hoTen), ['Danh']);
+  });
+
+  test('ly do: caches and falls back the same way', () async {
+    api.lyDoTraVe = [LyDo(id: 1, tieuDe: 'Phat bieu', bienDiem: 5)];
+    await repo.danhSachLyDo();
+
+    api.loiLyDo = Exception('mat_ket_noi');
+    final ds = await repo.danhSachLyDo();
+    expect(ds.single.tieuDe, 'Phat bieu');
+  });
+}

--- a/mobile/test/fakes/fake_diem_api.dart
+++ b/mobile/test/fakes/fake_diem_api.dart
@@ -1,0 +1,81 @@
+import 'package:dclass_mobile/api_client.dart';
+import 'package:dclass_mobile/models/hoc_sinh.dart';
+import 'package:dclass_mobile/models/ly_do.dart';
+import 'package:dclass_mobile/models/qua_tang.dart';
+
+/// Hand-rolled fake for [DiemApi] - lets tests script exactly what each call
+/// returns or throws, and records call order (for asserting the sync engine
+/// replays the outbox sequentially and in order).
+class FakeDiemApi implements DiemApi {
+  List<HocSinh> hocSinhTraVe = [];
+  List<LyDo> lyDoTraVe = [];
+  List<QuaTang> quaTangTraVe = [];
+
+  /// Set to make the corresponding read throw instead of returning data -
+  /// simulates being offline.
+  Object? loiHocSinh;
+  Object? loiLyDo;
+  Object? loiQuaTang;
+
+  /// Queue of results `congDiem`/`quyDoiQuaTang` return, one per call, in
+  /// order. Each entry is either a `Map<String, dynamic>` (success payload)
+  /// or any other [Object], which is thrown as-is.
+  final List<Object> hangDoiKetQua = [];
+
+  /// `'congDiem:<clientActionId>'` / `'quyDoiQuaTang:<clientActionId>'` for
+  /// every write call made so far, in call order.
+  final List<String> lenhDaGoi = [];
+
+  @override
+  Future<List<HocSinh>> danhSachHocSinh({
+    int? lopHocId,
+    String tuKhoa = '',
+  }) async {
+    if (loiHocSinh != null) throw loiHocSinh!;
+    return hocSinhTraVe;
+  }
+
+  @override
+  Future<List<LyDo>> danhSachLyDo() async {
+    if (loiLyDo != null) throw loiLyDo!;
+    return lyDoTraVe;
+  }
+
+  @override
+  Future<List<QuaTang>> danhSachQuaTang() async {
+    if (loiQuaTang != null) throw loiQuaTang!;
+    return quaTangTraVe;
+  }
+
+  Object _layKetQuaTiepTheo(String tenLenh, String? clientActionId) {
+    lenhDaGoi.add('$tenLenh:${clientActionId ?? ''}');
+    if (hangDoiKetQua.isEmpty) {
+      throw StateError('FakeDiemApi: no scripted result left for $tenLenh');
+    }
+    return hangDoiKetQua.removeAt(0);
+  }
+
+  @override
+  Future<Map<String, dynamic>> congDiem({
+    required int hocSinhId,
+    required int lyDoId,
+    String ghiChu = '',
+    String? clientActionId,
+  }) async {
+    final ketQua = _layKetQuaTiepTheo('congDiem', clientActionId);
+    if (ketQua is Map<String, dynamic>) return ketQua;
+    throw ketQua;
+  }
+
+  @override
+  Future<Map<String, dynamic>> quyDoiQuaTang({
+    required int hocSinhId,
+    required int quaTangId,
+    String ghiChu = '',
+    String? clientActionId,
+  }) async {
+    final ketQua = _layKetQuaTiepTheo('quyDoiQuaTang', clientActionId);
+    if (ketQua is Map<String, dynamic>) return ketQua;
+    throw ketQua;
+  }
+}


### PR DESCRIPTION
## Summary
Phase 1 of the approved offline+sync plan. **Stacked on #84** (Phase 0) — base branch is `claude/mobile-offline-sync-foundation`, not `main`, since this depends on its `DiemApi` interface and `app_database.dart` schema. Merge #84 first, then retarget/merge this one into `main`.

- Models (`HocSinh`/`LyDo`/`QuaTang`) gain `fromCacheRow`/`toCacheRow` matching the Phase 0 cache schema.
- `DanhMucRepository` (new): try the network first (freshest data, refreshes the cache for next time), fall back to the last-synced cache on failure — offline students/reasons/gifts viewing, on its own.
- `students_screen.dart` reads through the repository instead of `ApiClient` directly. The add-points write path is untouched here — that's Phase 2 (outbox).
- `main.dart`/`login_screen.dart` construct the `Database` + repository once and pass them down.
- `FakeDiemApi` (hand-rolled `DiemApi` test double, reusable by later phases) + `danh_muc_repository_test.dart`, exercising real in-memory SQLite via `sqflite_common_ffi`.

## Test plan
- [ ] `CI Flutter (mobile)` passes — `danh_muc_repository_test.dart` actually exercises the new cache tables against real SQLite (network-first fetch + upsert, offline fallback, empty-cache case, full-replace-not-append on refetch)
- [ ] Manual: log in against a real dev server, confirm student list loads; kill the server, pull-to-refresh, confirm the previously-loaded list still shows instead of an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)