### PR TITLE
mobile: Phase 2 outbox + write-side repository

### DIFF
--- a/mobile/lib/loi_phan_loai.dart
+++ b/mobile/lib/loi_phan_loai.dart
@@ -1,0 +1,37 @@
+import 'api_client.dart';
+
+/// Server error codes (see `lib/diem_nghiep_vu.php`) that are permanent -
+/// retrying the exact same request won't help unless something changes
+/// server-side first (a reason gets reactivated, stock gets restocked...).
+const _maLoiVinhVien = {
+  'ly_do_khong_hop_le',
+  'khong_du_quyen',
+  'qua_khong_hop_le',
+  'het_hang',
+  'khong_du_diem',
+  'thieu_thong_tin',
+};
+
+/// Whether [loi] is worth retrying later unchanged (network hiccup, server
+/// briefly down) as opposed to a permanent/business failure that needs the
+/// user - or a server-side change - to resolve. Shared by DiemRepository's
+/// immediate-attempt fallback and the sync engine's replay loop so both
+/// classify errors identically.
+bool laLoiTamThoi(Object loi) {
+  if (loi is ApiException) {
+    final ma = loi.thongBao;
+    if (_maLoiVinhVien.contains(ma)) return false;
+    if (ma.startsWith('loi_http_')) {
+      final maSo = int.tryParse(ma.substring('loi_http_'.length));
+      if (maSo != null) {
+        // Timeouts, rate-limiting, and any 5xx are worth retrying; other
+        // 4xx (401 bad/revoked token, 404, ...) are not.
+        return maSo == 408 || maSo == 429 || maSo >= 500;
+      }
+    }
+    return false; // unrecognized ApiException message: treat as permanent
+  }
+  // Anything else (SocketException, TimeoutException, http.ClientException,
+  // ...) is a network-level failure - always transient.
+  return true;
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3,7 +3,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'api_client.dart';
 import 'db/app_database.dart';
+import 'outbox/outbox_repository.dart';
 import 'repositories/danh_muc_repository.dart';
+import 'repositories/diem_repository.dart';
 import 'screens/login_screen.dart';
 import 'screens/students_screen.dart';
 
@@ -37,8 +39,8 @@ class _KhoiDong extends StatefulWidget {
 }
 
 class _KhoiDongState extends State<_KhoiDong> {
-  ApiClient? _client;
   DanhMucRepository? _danhMuc;
+  DiemRepository? _diem;
   bool _dangTai = true;
 
   @override
@@ -58,8 +60,8 @@ class _KhoiDongState extends State<_KhoiDong> {
     final client = ApiClient(baseUrl: baseUrl, token: token);
     final db = await openAppDatabase();
     setState(() {
-      _client = client;
       _danhMuc = DanhMucRepository(api: client, db: db);
+      _diem = DiemRepository(api: client, outbox: OutboxRepository(db));
       _dangTai = false;
     });
   }
@@ -69,8 +71,8 @@ class _KhoiDongState extends State<_KhoiDong> {
     if (_dangTai) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    return (_client == null || _danhMuc == null)
+    return (_danhMuc == null || _diem == null)
         ? const LoginScreen()
-        : StudentsScreen(client: _client!, danhMuc: _danhMuc!);
+        : StudentsScreen(danhMuc: _danhMuc!, diem: _diem!);
   }
 }

--- a/mobile/lib/outbox/hanh_dong_cho.dart
+++ b/mobile/lib/outbox/hanh_dong_cho.dart
@@ -1,0 +1,112 @@
+/// What kind of point transaction a queued action represents - matches the
+/// server's `so_cai_diem.loai` values ('CONG_DIEM' / 'DOI_DIEM').
+enum LoaiHanhDong {
+  congDiem,
+  doiQua;
+
+  String get gtri => this == LoaiHanhDong.congDiem ? 'CONG_DIEM' : 'DOI_DIEM';
+
+  static LoaiHanhDong tuChuoi(String s) {
+    return s == 'DOI_DIEM' ? LoaiHanhDong.doiQua : LoaiHanhDong.congDiem;
+  }
+}
+
+/// Lifecycle state of a queued action. See `mobile/lib/db/app_database.dart`
+/// for the `hang_doi_thao_tac.trang_thai` CHECK constraint this mirrors.
+enum TrangThaiHanhDong {
+  choXuLy,
+  dangGui,
+  loiVinhVien;
+
+  String get gtri {
+    switch (this) {
+      case TrangThaiHanhDong.choXuLy:
+        return 'cho_xu_ly';
+      case TrangThaiHanhDong.dangGui:
+        return 'dang_gui';
+      case TrangThaiHanhDong.loiVinhVien:
+        return 'loi_vinh_vien';
+    }
+  }
+
+  static TrangThaiHanhDong tuChuoi(String s) {
+    switch (s) {
+      case 'dang_gui':
+        return TrangThaiHanhDong.dangGui;
+      case 'loi_vinh_vien':
+        return TrangThaiHanhDong.loiVinhVien;
+      default:
+        return TrangThaiHanhDong.choXuLy;
+    }
+  }
+}
+
+/// A queued offline point action, one row of `hang_doi_thao_tac`. [id] is
+/// null until the row has been inserted (sqlite assigns it, and it's the
+/// strict FIFO ordering key - see the sync engine).
+class HanhDongCho {
+  final int? id;
+  final String clientActionId;
+  final LoaiHanhDong loai;
+  final int hocSinhId;
+  final int? lyDoId;
+  final int? quaTangId;
+  final String ghiChu;
+  final TrangThaiHanhDong trangThai;
+  final String? loiMa;
+  final int soLanThu;
+  final String taoLuc;
+  final String? capNhatLuc;
+
+  HanhDongCho({
+    this.id,
+    required this.clientActionId,
+    required this.loai,
+    required this.hocSinhId,
+    this.lyDoId,
+    this.quaTangId,
+    this.ghiChu = '',
+    this.trangThai = TrangThaiHanhDong.choXuLy,
+    this.loiMa,
+    this.soLanThu = 0,
+    required this.taoLuc,
+    this.capNhatLuc,
+  });
+
+  factory HanhDongCho.fromRow(Map<String, Object?> row) {
+    return HanhDongCho(
+      id: row['id'] as int?,
+      clientActionId: row['client_action_id'] as String,
+      loai: LoaiHanhDong.tuChuoi(row['loai'] as String),
+      hocSinhId: row['hoc_sinh_id'] as int,
+      lyDoId: row['ly_do_id'] as int?,
+      quaTangId: row['qua_tang_id'] as int?,
+      ghiChu: row['ghi_chu'] as String? ?? '',
+      trangThai: TrangThaiHanhDong.tuChuoi(
+        row['trang_thai'] as String? ?? 'cho_xu_ly',
+      ),
+      loiMa: row['loi_ma'] as String?,
+      soLanThu: (row['so_lan_thu'] as num?)?.toInt() ?? 0,
+      taoLuc: row['tao_luc'] as String,
+      capNhatLuc: row['cap_nhat_luc'] as String?,
+    );
+  }
+
+  Map<String, Object?> toRow() {
+    final row = <String, Object?>{
+      'client_action_id': clientActionId,
+      'loai': loai.gtri,
+      'hoc_sinh_id': hocSinhId,
+      'ly_do_id': lyDoId,
+      'qua_tang_id': quaTangId,
+      'ghi_chu': ghiChu,
+      'trang_thai': trangThai.gtri,
+      'loi_ma': loiMa,
+      'so_lan_thu': soLanThu,
+      'tao_luc': taoLuc,
+      'cap_nhat_luc': capNhatLuc,
+    };
+    if (id != null) row['id'] = id;
+    return row;
+  }
+}

--- a/mobile/lib/outbox/outbox_repository.dart
+++ b/mobile/lib/outbox/outbox_repository.dart
@@ -1,0 +1,108 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'hanh_dong_cho.dart';
+
+const String _bang = 'hang_doi_thao_tac';
+
+/// Persists the queue of offline point actions and their lifecycle
+/// transitions. Ordering for replay is always the local autoincrement `id`
+/// (`ORDER BY id ASC`), not `tao_luc` - avoids any clock-skew concern and
+/// matches insertion order exactly for a single-writer, single-device app.
+class OutboxRepository {
+  OutboxRepository(this.db);
+  final Database db;
+
+  Future<int> themMoi(HanhDongCho hanhDong) {
+    return db.insert(_bang, hanhDong.toRow());
+  }
+
+  /// All actions still needing to be sent, oldest first. Excludes
+  /// permanently-failed actions - those are surfaced separately via
+  /// [layDanhSachLoiVinhVien] and never auto-retried.
+  Future<List<HanhDongCho>> layDanhSachChoXuLy() async {
+    final rows = await db.query(
+      _bang,
+      where: 'trang_thai != ?',
+      whereArgs: [TrangThaiHanhDong.loiVinhVien.gtri],
+      orderBy: 'id ASC',
+    );
+    return rows.map(HanhDongCho.fromRow).toList();
+  }
+
+  Future<List<HanhDongCho>> layDanhSachLoiVinhVien() async {
+    final rows = await db.query(
+      _bang,
+      where: 'trang_thai = ?',
+      whereArgs: [TrangThaiHanhDong.loiVinhVien.gtri],
+      orderBy: 'id ASC',
+    );
+    return rows.map(HanhDongCho.fromRow).toList();
+  }
+
+  Future<void> danDauDangGui(int id) {
+    return db.update(
+      _bang,
+      {
+        'trang_thai': TrangThaiHanhDong.dangGui.gtri,
+        'cap_nhat_luc': DateTime.now().toIso8601String(),
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<void> danhDauLoiVinhVien(int id, String maLoi) {
+    return db.update(
+      _bang,
+      {
+        'trang_thai': TrangThaiHanhDong.loiVinhVien.gtri,
+        'loi_ma': maLoi,
+        'cap_nhat_luc': DateTime.now().toIso8601String(),
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  /// Resets an action back to pending (incrementing its attempt count) -
+  /// used both for a transient-failure retry and for a user-initiated
+  /// "Thử lại" on a previously permanently-failed action.
+  Future<void> datLaiChoXuLy(int id) {
+    return db.rawUpdate(
+      'UPDATE $_bang SET trang_thai = ?, so_lan_thu = so_lan_thu + 1, '
+      'cap_nhat_luc = ? WHERE id = ?',
+      [TrangThaiHanhDong.choXuLy.gtri, DateTime.now().toIso8601String(), id],
+    );
+  }
+
+  /// Resets any action left `dang_gui` (in-flight) back to `cho_xu_ly` -
+  /// call once when the sync engine starts. Safe because the server's
+  /// `client_action_id` idempotency guarantees a resend either double-checks
+  /// harmlessly or applies fresh - see so_cai_diem's partial unique index.
+  Future<void> quetDangGuiConLai() {
+    return db.update(
+      _bang,
+      {'trang_thai': TrangThaiHanhDong.choXuLy.gtri},
+      where: 'trang_thai = ?',
+      whereArgs: [TrangThaiHanhDong.dangGui.gtri],
+    );
+  }
+
+  Future<int> demSoLuongChoXuLy() async {
+    final ketQua = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM $_bang WHERE trang_thai != ?',
+      [TrangThaiHanhDong.loiVinhVien.gtri],
+    );
+    return Sqflite.firstIntValue(ketQua) ?? 0;
+  }
+
+  /// Deletes a successfully-synced action - the server's own ledger
+  /// (`api/diem.php?hanh_dong=lich_su`) is the durable record, no need to
+  /// keep a local copy once it's confirmed applied.
+  Future<void> xoaSauKhiThanhCong(int id) => xoa(id);
+
+  /// User-initiated discard of a permanently-failed action.
+  Future<void> xoa(int id) {
+    return db.delete(_bang, where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/mobile/lib/repositories/diem_repository.dart
+++ b/mobile/lib/repositories/diem_repository.dart
@@ -1,0 +1,83 @@
+import 'package:uuid/uuid.dart';
+
+import '../api_client.dart';
+import '../loi_phan_loai.dart';
+import '../outbox/hanh_dong_cho.dart';
+import '../outbox/outbox_repository.dart';
+
+const _uuid = Uuid();
+
+enum KetQuaGhiDiem { daApDungNgay, dangCho }
+
+/// Write-side entry point for point actions. Tries the network immediately,
+/// so the common case (online) still gets synchronous success/failure
+/// feedback; only queues the action (via [OutboxRepository], to be replayed
+/// later by the sync engine) when the immediate attempt fails for a
+/// transient reason. A permanent/business failure (e.g. an inactive reason,
+/// insufficient balance) is surfaced to the caller right away instead of
+/// silently queued to fail again identically later.
+class DiemRepository {
+  DiemRepository({required this.api, required this.outbox});
+  final DiemApi api;
+  final OutboxRepository outbox;
+
+  Future<KetQuaGhiDiem> themCongDiem({
+    required int hocSinhId,
+    required int lyDoId,
+    String ghiChu = '',
+  }) async {
+    final clientActionId = _uuid.v4();
+    try {
+      await api.congDiem(
+        hocSinhId: hocSinhId,
+        lyDoId: lyDoId,
+        ghiChu: ghiChu,
+        clientActionId: clientActionId,
+      );
+      return KetQuaGhiDiem.daApDungNgay;
+    } catch (loi) {
+      if (!laLoiTamThoi(loi)) rethrow;
+      await outbox.themMoi(
+        HanhDongCho(
+          clientActionId: clientActionId,
+          loai: LoaiHanhDong.congDiem,
+          hocSinhId: hocSinhId,
+          lyDoId: lyDoId,
+          ghiChu: ghiChu,
+          taoLuc: DateTime.now().toIso8601String(),
+        ),
+      );
+      return KetQuaGhiDiem.dangCho;
+    }
+  }
+
+  Future<KetQuaGhiDiem> themDoiQua({
+    required int hocSinhId,
+    required int quaTangId,
+    String ghiChu = '',
+  }) async {
+    final clientActionId = _uuid.v4();
+    try {
+      await api.quyDoiQuaTang(
+        hocSinhId: hocSinhId,
+        quaTangId: quaTangId,
+        ghiChu: ghiChu,
+        clientActionId: clientActionId,
+      );
+      return KetQuaGhiDiem.daApDungNgay;
+    } catch (loi) {
+      if (!laLoiTamThoi(loi)) rethrow;
+      await outbox.themMoi(
+        HanhDongCho(
+          clientActionId: clientActionId,
+          loai: LoaiHanhDong.doiQua,
+          hocSinhId: hocSinhId,
+          quaTangId: quaTangId,
+          ghiChu: ghiChu,
+          taoLuc: DateTime.now().toIso8601String(),
+        ),
+      );
+      return KetQuaGhiDiem.dangCho;
+    }
+  }
+}

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -4,7 +4,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../api_client.dart';
 import '../db/app_database.dart';
 import '../main.dart';
+import '../outbox/outbox_repository.dart';
 import '../repositories/danh_muc_repository.dart';
+import '../repositories/diem_repository.dart';
 import 'students_screen.dart';
 
 /// Lets a teacher point the app at their DClass server and paste the API
@@ -47,10 +49,11 @@ class _LoginScreenState extends State<LoginScreen> {
       await prefs.setString(prefsToken, token);
       final db = await openAppDatabase();
       final danhMuc = DanhMucRepository(api: client, db: db);
+      final diem = DiemRepository(api: client, outbox: OutboxRepository(db));
       if (!mounted) return;
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(
-          builder: (_) => StudentsScreen(client: client, danhMuc: danhMuc),
+          builder: (_) => StudentsScreen(danhMuc: danhMuc, diem: diem),
         ),
       );
     } catch (e) {

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -1,23 +1,17 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
-import '../api_client.dart';
 import '../models/hoc_sinh.dart';
 import '../models/ly_do.dart';
 import '../repositories/danh_muc_repository.dart';
+import '../repositories/diem_repository.dart';
 
 /// Student list with a quick "add points" action per row - the core
 /// in-class flow the mobile app exists for (web stays the tool for
 /// admin/reports/setup).
 class StudentsScreen extends StatefulWidget {
-  final ApiClient client;
   final DanhMucRepository danhMuc;
-  const StudentsScreen({
-    super.key,
-    required this.client,
-    required this.danhMuc,
-  });
+  final DiemRepository diem;
+  const StudentsScreen({super.key, required this.danhMuc, required this.diem});
 
   @override
   State<StudentsScreen> createState() => _StudentsScreenState();
@@ -35,11 +29,6 @@ class _StudentsScreenState extends State<StudentsScreen> {
   Future<void> _lamMoi() async {
     setState(() => _hocSinh = widget.danhMuc.danhSachHocSinh());
     await _hocSinh;
-  }
-
-  String _taoClientActionId() {
-    final r = Random();
-    return '${DateTime.now().microsecondsSinceEpoch}-${r.nextInt(1 << 32)}';
   }
 
   Future<void> _chonLyDoVaCongDiem(HocSinh hs) async {
@@ -75,15 +64,17 @@ class _StudentsScreenState extends State<StudentsScreen> {
     );
     if (lyDo == null) return;
     try {
-      await widget.client.congDiem(
+      final ketQua = await widget.diem.themCongDiem(
         hocSinhId: hs.id,
         lyDoId: lyDo.id,
-        clientActionId: _taoClientActionId(),
       );
       if (!mounted) return;
+      final thongBao = ketQua == KetQuaGhiDiem.daApDungNgay
+          ? 'Đã cộng điểm cho ${hs.hoTen}'
+          : 'Đã ghi nhận cho ${hs.hoTen} - sẽ đồng bộ khi có mạng';
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Đã cộng điểm cho ${hs.hoTen}')));
+      ).showSnackBar(SnackBar(content: Text(thongBao)));
       await _lamMoi();
     } catch (e) {
       if (!mounted) return;

--- a/mobile/test/diem_repository_test.dart
+++ b/mobile/test/diem_repository_test.dart
@@ -1,0 +1,65 @@
+import 'package:dclass_mobile/api_client.dart';
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/outbox/outbox_repository.dart';
+import 'package:dclass_mobile/repositories/diem_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'fakes/fake_diem_api.dart';
+
+void main() {
+  late FakeDiemApi api;
+  late OutboxRepository outbox;
+  late DiemRepository repo;
+
+  setUp(() async {
+    api = FakeDiemApi();
+    final db = await openAppDatabase(path: inMemoryDatabasePath);
+    outbox = OutboxRepository(db);
+    repo = DiemRepository(api: api, outbox: outbox);
+  });
+
+  test('online success: applies immediately, nothing queued', () async {
+    api.hangDoiKetQua.add({'so_du': 15});
+
+    final ketQua = await repo.themCongDiem(hocSinhId: 1, lyDoId: 2);
+
+    expect(ketQua, KetQuaGhiDiem.daApDungNgay);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+    expect(api.lenhDaGoi, hasLength(1));
+  });
+
+  test('transient failure: queues the action instead of throwing', () async {
+    api.hangDoiKetQua.add(Exception('SocketException: mat ket noi'));
+
+    final ketQua = await repo.themCongDiem(hocSinhId: 1, lyDoId: 2);
+
+    expect(ketQua, KetQuaGhiDiem.dangCho);
+    final ds = await outbox.layDanhSachChoXuLy();
+    expect(ds, hasLength(1));
+    expect(ds.single.hocSinhId, 1);
+    expect(ds.single.lyDoId, 2);
+  });
+
+  test('permanent failure: rethrows and does not queue', () async {
+    api.hangDoiKetQua.add(ApiException('het_hang'));
+
+    await expectLater(
+      () => repo.themDoiQua(hocSinhId: 1, quaTangId: 5),
+      throwsA(isA<ApiException>()),
+    );
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test(
+    'the same clientActionId used in the API call is stored on the queued row',
+    () async {
+      api.hangDoiKetQua.add(Exception('timeout'));
+      await repo.themCongDiem(hocSinhId: 1, lyDoId: 2);
+
+      final goiVoi = api.lenhDaGoi.single.split(':').last;
+      final ds = await outbox.layDanhSachChoXuLy();
+      expect(ds.single.clientActionId, goiVoi);
+    },
+  );
+}

--- a/mobile/test/outbox_repository_test.dart
+++ b/mobile/test/outbox_repository_test.dart
@@ -1,0 +1,112 @@
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/outbox/hanh_dong_cho.dart';
+import 'package:dclass_mobile/outbox/outbox_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+HanhDongCho _hanhDongMau({String clientActionId = 'ca-1', int hocSinhId = 1}) {
+  return HanhDongCho(
+    clientActionId: clientActionId,
+    loai: LoaiHanhDong.congDiem,
+    hocSinhId: hocSinhId,
+    lyDoId: 1,
+    taoLuc: DateTime.now().toIso8601String(),
+  );
+}
+
+void main() {
+  late OutboxRepository outbox;
+
+  setUp(() async {
+    final db = await openAppDatabase(path: inMemoryDatabasePath);
+    outbox = OutboxRepository(db);
+  });
+
+  test(
+    'layDanhSachChoXuLy returns rows in strict insertion (id) order',
+    () async {
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-2'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-3'));
+
+      final ds = await outbox.layDanhSachChoXuLy();
+
+      expect(ds.map((e) => e.clientActionId), ['ca-1', 'ca-2', 'ca-3']);
+      expect(ds.every((e) => e.trangThai == TrangThaiHanhDong.choXuLy), isTrue);
+    },
+  );
+
+  test(
+    'a permanently-failed action is excluded from layDanhSachChoXuLy',
+    () async {
+      final id1 = await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-2'));
+
+      await outbox.danhDauLoiVinhVien(id1, 'het_hang');
+
+      final choXuLy = await outbox.layDanhSachChoXuLy();
+      expect(choXuLy.map((e) => e.clientActionId), ['ca-2']);
+
+      final loi = await outbox.layDanhSachLoiVinhVien();
+      expect(loi, hasLength(1));
+      expect(loi.single.clientActionId, 'ca-1');
+      expect(loi.single.loiMa, 'het_hang');
+    },
+  );
+
+  test('quetDangGuiConLai resets leftover in-flight rows to pending', () async {
+    final id = await outbox.themMoi(_hanhDongMau());
+    await outbox.danDauDangGui(id);
+
+    // Simulate the app being killed mid-send: the row is stuck "dang_gui".
+    var ds = await outbox.layDanhSachChoXuLy();
+    expect(ds.single.trangThai, TrangThaiHanhDong.dangGui);
+
+    await outbox.quetDangGuiConLai();
+
+    ds = await outbox.layDanhSachChoXuLy();
+    expect(ds.single.trangThai, TrangThaiHanhDong.choXuLy);
+  });
+
+  test('datLaiChoXuLy resets state and increments the attempt count', () async {
+    final id = await outbox.themMoi(_hanhDongMau());
+    await outbox.danDauDangGui(id);
+
+    await outbox.datLaiChoXuLy(id);
+
+    final ds = await outbox.layDanhSachChoXuLy();
+    expect(ds.single.trangThai, TrangThaiHanhDong.choXuLy);
+    expect(ds.single.soLanThu, 1);
+  });
+
+  test(
+    'xoa removes a permanently-failed action for good (user discard)',
+    () async {
+      final id = await outbox.themMoi(_hanhDongMau());
+      await outbox.danhDauLoiVinhVien(id, 'khong_du_diem');
+
+      await outbox.xoa(id);
+
+      expect(await outbox.layDanhSachLoiVinhVien(), isEmpty);
+      expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+    },
+  );
+
+  test('xoaSauKhiThanhCong removes a completed action', () async {
+    final id = await outbox.themMoi(_hanhDongMau());
+    await outbox.xoaSauKhiThanhCong(id);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test(
+    'demSoLuongChoXuLy counts everything except permanent failures',
+    () async {
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-1'));
+      final id2 = await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-2'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-3'));
+      await outbox.danhDauLoiVinhVien(id2, 'het_hang');
+
+      expect(await outbox.demSoLuongChoXuLy(), 2);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Phase 2 of the approved offline+sync plan. **Stacked on #85** (Phase 1, which is itself stacked on #84). Merge order: #84 → #85 → this one → `main`.

- `hang_doi_thao_tac` model/repository (`outbox/hanh_dong_cho.dart`, `outbox/outbox_repository.dart`): insert, strict `id ASC` ordering for FIFO replay, permanent-vs-pending queries, the `dang_gui` startup sweep, and discard/retry transitions.
- `loi_phan_loai.dart`: classifies an error as transient (network hiccup, 5xx/408/429 - worth retrying later unchanged) vs. permanent (the server's business error codes, or another 4xx) - shared by `DiemRepository` here and by the sync engine in the next phase, so both classify identically.
- `DiemRepository` (new): the write-side entry point. Tries the network immediately (so the common online case still gets synchronous feedback); only queues the action when the attempt fails transiently. A permanent failure is rethrown immediately instead of being queued to fail again identically later.
- `students_screen.dart` routes its add-points flow through `DiemRepository` instead of `ApiClient` directly, using the uuid the repository generates instead of the old timestamp-based `_taoClientActionId()`; the snackbar now distinguishes "applied now" from "queued, will sync when possible".

Also includes a fix (in #85 after rebase) for a real bug CI caught: `openAppDatabase` needs `singleInstance: false` for test-provided paths, otherwise every test opening `inMemoryDatabasePath` shared the same cached in-memory database.

## Test plan
- [ ] `CI Flutter (mobile)` passes — `outbox_repository_test.dart` (ordering, sweep, discard/retry) and `diem_repository_test.dart` (immediate success / transient-queues / permanent-rethrows, against `FakeDiemApi`)
- [ ] Manual: with the dev server reachable, add points to a student, confirm the "applied now" message and updated balance; stop the server, add points again, confirm the "queued" message instead of an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)