### PR TITLE
mobile: Phase 3 sync engine + triggers

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite/sqflite.dart';
 
 import 'api_client.dart';
 import 'db/app_database.dart';
-import 'outbox/outbox_repository.dart';
-import 'repositories/danh_muc_repository.dart';
-import 'repositories/diem_repository.dart';
+import 'phien_dang_nhap.dart';
 import 'screens/login_screen.dart';
-import 'screens/students_screen.dart';
 
 const String prefsBaseUrl = 'base_url';
 const String prefsToken = 'api_token';
@@ -39,8 +37,8 @@ class _KhoiDong extends StatefulWidget {
 }
 
 class _KhoiDongState extends State<_KhoiDong> {
-  DanhMucRepository? _danhMuc;
-  DiemRepository? _diem;
+  ApiClient? _client;
+  Database? _db;
   bool _dangTai = true;
 
   @override
@@ -60,8 +58,8 @@ class _KhoiDongState extends State<_KhoiDong> {
     final client = ApiClient(baseUrl: baseUrl, token: token);
     final db = await openAppDatabase();
     setState(() {
-      _danhMuc = DanhMucRepository(api: client, db: db);
-      _diem = DiemRepository(api: client, outbox: OutboxRepository(db));
+      _client = client;
+      _db = db;
       _dangTai = false;
     });
   }
@@ -71,8 +69,8 @@ class _KhoiDongState extends State<_KhoiDong> {
     if (_dangTai) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    return (_danhMuc == null || _diem == null)
+    return (_client == null || _db == null)
         ? const LoginScreen()
-        : StudentsScreen(danhMuc: _danhMuc!, diem: _diem!);
+        : PhienDangNhap(client: _client!, db: _db!);
   }
 }

--- a/mobile/lib/phien_dang_nhap.dart
+++ b/mobile/lib/phien_dang_nhap.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:sqflite/sqflite.dart';
+
+import 'api_client.dart';
+import 'outbox/outbox_repository.dart';
+import 'repositories/danh_muc_repository.dart';
+import 'repositories/diem_repository.dart';
+import 'screens/students_screen.dart';
+import 'sync/app_lifecycle_sync_trigger.dart';
+import 'sync/connectivity_watcher.dart';
+import 'sync/sync_engine.dart';
+
+/// Everything a logged-in session needs: repositories, the sync engine, its
+/// connectivity + app-resume triggers, and the student list. Built once
+/// [client]/[db] are ready - both entry points (cold start via `main.dart`,
+/// and a fresh login via `login_screen.dart`) already have both in hand by
+/// the time they reach this widget.
+class PhienDangNhap extends StatefulWidget {
+  const PhienDangNhap({super.key, required this.client, required this.db});
+
+  final ApiClient client;
+  final Database db;
+
+  @override
+  State<PhienDangNhap> createState() => _PhienDangNhapState();
+}
+
+class _PhienDangNhapState extends State<PhienDangNhap> {
+  late final DanhMucRepository _danhMuc;
+  late final DiemRepository _diem;
+  late final SyncEngine _syncEngine;
+  StreamSubscription<bool>? _dangKyKetNoi;
+
+  @override
+  void initState() {
+    super.initState();
+    final outbox = OutboxRepository(widget.db);
+    _danhMuc = DanhMucRepository(api: widget.client, db: widget.db);
+    _diem = DiemRepository(api: widget.client, outbox: outbox);
+    _syncEngine = SyncEngine(
+      api: widget.client,
+      outbox: outbox,
+      danhMuc: _danhMuc,
+    );
+    _dangKyKetNoi = ConnectivityWatcher().thayDoi.listen((coKetNoi) {
+      if (coKetNoi) _syncEngine.chaySync();
+    });
+    // Catch up on anything queued from a previous session on startup too.
+    _syncEngine.chaySync();
+  }
+
+  @override
+  void dispose() {
+    _dangKyKetNoi?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppLifecycleSyncTrigger(
+      syncEngine: _syncEngine,
+      child: StudentsScreen(
+        danhMuc: _danhMuc,
+        diem: _diem,
+        syncEngine: _syncEngine,
+      ),
+    );
+  }
+}

--- a/mobile/lib/repositories/danh_muc_repository.dart
+++ b/mobile/lib/repositories/danh_muc_repository.dart
@@ -79,10 +79,16 @@ class DanhMucRepository {
 
   /// Best-effort local decrement after a redeem syncs (the API response
   /// doesn't echo remaining stock) - corrected for real on the next
-  /// [danhSachQuaTang] refresh.
+  /// [danhSachQuaTang] refresh. Mirrors the server's own rule (see
+  /// quy_doi_qua_tang in lib/diem_nghiep_vu.php): only decrement when stock
+  /// is a real positive count. A negative ton_kho means "unlimited" and is
+  /// never touched - `MAX(x - 1, 0)` would wrongly turn -1 into 0 (looking
+  /// out of stock) after a single redeem.
   Future<void> giamTonKhoQuaTang(int quaTangId) {
     return db.rawUpdate(
-      'UPDATE qua_tang_cache SET ton_kho_may_chu = MAX(ton_kho_may_chu - 1, 0), '
+      'UPDATE qua_tang_cache SET '
+      'ton_kho_may_chu = CASE WHEN ton_kho_may_chu > 0 '
+      'THEN ton_kho_may_chu - 1 ELSE ton_kho_may_chu END, '
       'cap_nhat_luc = ? WHERE id = ?',
       [DateTime.now().toIso8601String(), quaTangId],
     );

--- a/mobile/lib/repositories/danh_muc_repository.dart
+++ b/mobile/lib/repositories/danh_muc_repository.dart
@@ -61,4 +61,30 @@ class DanhMucRepository {
       return rows.map(QuaTang.fromCacheRow).toList();
     }
   }
+
+  /// Reconciles a cached balance after the sync engine confirms an action
+  /// applied - the server's response is authoritative (it may differ from
+  /// what was assumed offline, e.g. a gift's price changed in the meantime).
+  Future<void> capNhatSoDuHocSinh(int hocSinhId, int soDuMoi) {
+    return db.update(
+      'hoc_sinh_cache',
+      {
+        'so_du_may_chu': soDuMoi,
+        'cap_nhat_luc': DateTime.now().toIso8601String(),
+      },
+      where: 'id = ?',
+      whereArgs: [hocSinhId],
+    );
+  }
+
+  /// Best-effort local decrement after a redeem syncs (the API response
+  /// doesn't echo remaining stock) - corrected for real on the next
+  /// [danhSachQuaTang] refresh.
+  Future<void> giamTonKhoQuaTang(int quaTangId) {
+    return db.rawUpdate(
+      'UPDATE qua_tang_cache SET ton_kho_may_chu = MAX(ton_kho_may_chu - 1, 0), '
+      'cap_nhat_luc = ? WHERE id = ?',
+      [DateTime.now().toIso8601String(), quaTangId],
+    );
+  }
 }

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -4,10 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../api_client.dart';
 import '../db/app_database.dart';
 import '../main.dart';
-import '../outbox/outbox_repository.dart';
-import '../repositories/danh_muc_repository.dart';
-import '../repositories/diem_repository.dart';
-import 'students_screen.dart';
+import '../phien_dang_nhap.dart';
 
 /// Lets a teacher point the app at their DClass server and paste the API
 /// token generated from cau_hinh.php's "Tài khoản" tab (shown there as text
@@ -48,12 +45,10 @@ class _LoginScreenState extends State<LoginScreen> {
       await prefs.setString(prefsBaseUrl, baseUrl);
       await prefs.setString(prefsToken, token);
       final db = await openAppDatabase();
-      final danhMuc = DanhMucRepository(api: client, db: db);
-      final diem = DiemRepository(api: client, outbox: OutboxRepository(db));
       if (!mounted) return;
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(
-          builder: (_) => StudentsScreen(danhMuc: danhMuc, diem: diem),
+          builder: (_) => PhienDangNhap(client: client, db: db),
         ),
       );
     } catch (e) {

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -4,6 +4,7 @@ import '../models/hoc_sinh.dart';
 import '../models/ly_do.dart';
 import '../repositories/danh_muc_repository.dart';
 import '../repositories/diem_repository.dart';
+import '../sync/sync_engine.dart';
 
 /// Student list with a quick "add points" action per row - the core
 /// in-class flow the mobile app exists for (web stays the tool for
@@ -11,7 +12,13 @@ import '../repositories/diem_repository.dart';
 class StudentsScreen extends StatefulWidget {
   final DanhMucRepository danhMuc;
   final DiemRepository diem;
-  const StudentsScreen({super.key, required this.danhMuc, required this.diem});
+  final SyncEngine syncEngine;
+  const StudentsScreen({
+    super.key,
+    required this.danhMuc,
+    required this.diem,
+    required this.syncEngine,
+  });
 
   @override
   State<StudentsScreen> createState() => _StudentsScreenState();
@@ -27,6 +34,7 @@ class _StudentsScreenState extends State<StudentsScreen> {
   }
 
   Future<void> _lamMoi() async {
+    await widget.syncEngine.chaySync();
     setState(() => _hocSinh = widget.danhMuc.danhSachHocSinh());
     await _hocSinh;
   }

--- a/mobile/lib/sync/app_lifecycle_sync_trigger.dart
+++ b/mobile/lib/sync/app_lifecycle_sync_trigger.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+import 'sync_engine.dart';
+
+/// Triggers a sync whenever the app returns to the foreground. Wraps the
+/// whole authenticated shell (see `phien_dang_nhap.dart`) rather than being
+/// mixed into individual screens, so it fires regardless of which screen
+/// happens to be showing on resume.
+class AppLifecycleSyncTrigger extends StatefulWidget {
+  const AppLifecycleSyncTrigger({
+    super.key,
+    required this.syncEngine,
+    required this.child,
+  });
+
+  final SyncEngine syncEngine;
+  final Widget child;
+
+  @override
+  State<AppLifecycleSyncTrigger> createState() =>
+      _AppLifecycleSyncTriggerState();
+}
+
+class _AppLifecycleSyncTriggerState extends State<AppLifecycleSyncTrigger>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      widget.syncEngine.chaySync();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/mobile/lib/sync/connectivity_watcher.dart
+++ b/mobile/lib/sync/connectivity_watcher.dart
@@ -1,0 +1,22 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// Collapses connectivity_plus's per-interface result list down to the
+/// single boolean the sync engine cares about: "is there any connection at
+/// all right now".
+class ConnectivityWatcher {
+  ConnectivityWatcher() : _connectivity = Connectivity();
+  final Connectivity _connectivity;
+
+  /// Emits whenever overall connectivity changes (regained or lost).
+  Stream<bool> get thayDoi {
+    return _connectivity.onConnectivityChanged.map(_coKetNoi).distinct();
+  }
+
+  Future<bool> coKetNoiHienTai() async {
+    return _coKetNoi(await _connectivity.checkConnectivity());
+  }
+
+  bool _coKetNoi(List<ConnectivityResult> ds) {
+    return ds.any((r) => r != ConnectivityResult.none);
+  }
+}

--- a/mobile/lib/sync/sync_engine.dart
+++ b/mobile/lib/sync/sync_engine.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+
+import '../api_client.dart';
+import '../loi_phan_loai.dart';
+import '../outbox/hanh_dong_cho.dart';
+import '../outbox/outbox_repository.dart';
+import '../repositories/danh_muc_repository.dart';
+
+/// Replays the queued outbox against the server, strictly in order. The
+/// server has no notion of "client's expected prior balance" - every write
+/// recomputes from live state - so an out-of-order replay can change
+/// business outcome even though every individual call is safely retryable
+/// (e.g. a queued "redeem gift" replayed before a queued "earn points" can
+/// fail for insufficient balance, even though the original order would have
+/// succeeded). Foreground-only by design: triggered by connectivity regained
+/// ([ConnectivityWatcher]), app resume ([AppLifecycleSyncTrigger]), manual
+/// pull-to-refresh, or an explicit "sync now" action - never a background
+/// service.
+class SyncEngine extends ChangeNotifier {
+  SyncEngine({required this.api, required this.outbox, required this.danhMuc});
+
+  final DiemApi api;
+  final OutboxRepository outbox;
+  final DanhMucRepository danhMuc;
+
+  bool dangDongBo = false;
+  int soLuongChoXuLy = 0;
+  String? loiGanNhat;
+
+  Future<void>? _dangChay;
+
+  /// Runs a sync pass. Concurrent callers while one is already in flight
+  /// await that same pass rather than starting a parallel one.
+  Future<void> chaySync() {
+    final dangChay = _dangChay;
+    if (dangChay != null) return dangChay;
+    final future = _chayThuc();
+    _dangChay = future;
+    return future.whenComplete(() => _dangChay = null);
+  }
+
+  Future<void> _chayThuc() async {
+    dangDongBo = true;
+    notifyListeners();
+    try {
+      // An app kill mid-send can leave a row stuck "dang_gui" - safe to
+      // reset because the server's client_action_id idempotency guarantees
+      // a resend either double-checks harmlessly or applies fresh.
+      await outbox.quetDangGuiConLai();
+      final danhSach = await outbox.layDanhSachChoXuLy();
+      for (final hanhDong in danhSach) {
+        final tiepTuc = await _xuLyMot(hanhDong);
+        if (!tiepTuc) break;
+      }
+    } finally {
+      soLuongChoXuLy = await outbox.demSoLuongChoXuLy();
+      dangDongBo = false;
+      notifyListeners();
+    }
+  }
+
+  /// Sends one queued action. Returns whether the batch should continue to
+  /// the next item.
+  Future<bool> _xuLyMot(HanhDongCho hanhDong) async {
+    final id = hanhDong.id!;
+    await outbox.danDauDangGui(id);
+    try {
+      final Map<String, dynamic> ketQua;
+      if (hanhDong.loai == LoaiHanhDong.congDiem) {
+        ketQua = await api.congDiem(
+          hocSinhId: hanhDong.hocSinhId,
+          lyDoId: hanhDong.lyDoId!,
+          ghiChu: hanhDong.ghiChu,
+          clientActionId: hanhDong.clientActionId,
+        );
+      } else {
+        ketQua = await api.quyDoiQuaTang(
+          hocSinhId: hanhDong.hocSinhId,
+          quaTangId: hanhDong.quaTangId!,
+          ghiChu: hanhDong.ghiChu,
+          clientActionId: hanhDong.clientActionId,
+        );
+      }
+      final soDu = (ketQua['so_du'] as num?)?.toInt();
+      if (soDu != null) {
+        await danhMuc.capNhatSoDuHocSinh(hanhDong.hocSinhId, soDu);
+      }
+      if (hanhDong.loai == LoaiHanhDong.doiQua && hanhDong.quaTangId != null) {
+        await danhMuc.giamTonKhoQuaTang(hanhDong.quaTangId!);
+      }
+      await outbox.xoaSauKhiThanhCong(id);
+      loiGanNhat = null;
+      return true;
+    } catch (loi) {
+      if (laLoiTamThoi(loi)) {
+        // Order must not be skipped over here: a later item running before
+        // this unresolved one would break the replay-in-order guarantee.
+        await outbox.datLaiChoXuLy(id);
+        loiGanNhat = loi.toString();
+        return false;
+      }
+      // A failed call makes no server-side state change (the PHP either
+      // throws before any write or rolls back its transaction), so later
+      // queued items still see real, unperturbed server state - safe to
+      // skip this one and continue.
+      final maLoi = loi is ApiException ? loi.thongBao : loi.toString();
+      await outbox.danhDauLoiVinhVien(id, maLoi);
+      return true;
+    }
+  }
+}

--- a/mobile/test/danh_muc_repository_test.dart
+++ b/mobile/test/danh_muc_repository_test.dart
@@ -1,19 +1,22 @@
 import 'package:dclass_mobile/db/app_database.dart';
 import 'package:dclass_mobile/models/hoc_sinh.dart';
 import 'package:dclass_mobile/models/ly_do.dart';
+import 'package:dclass_mobile/models/qua_tang.dart';
 import 'package:dclass_mobile/repositories/danh_muc_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'fakes/fake_diem_api.dart';
 
 void main() {
   late FakeDiemApi api;
+  late Database db;
   late DanhMucRepository repo;
 
   setUp(() async {
     api = FakeDiemApi();
-    final db = await openAppDatabase(path: inMemoryDatabasePath);
+    db = await openAppDatabase(path: inMemoryDatabasePath);
     repo = DanhMucRepository(api: api, db: db);
   });
 
@@ -109,4 +112,33 @@ void main() {
     final ds = await repo.danhSachLyDo();
     expect(ds.single.tieuDe, 'Phat bieu');
   });
+
+  test('giamTonKhoQuaTang decrements a positive stock by one', () async {
+    final qt = QuaTang(id: 1, ten: 'Keo', giaDiem: 3, tonKho: 5, anhUrl: null);
+    await db.insert('qua_tang_cache', qt.toCacheRow());
+
+    await repo.giamTonKhoQuaTang(1);
+
+    final rows = await db.query('qua_tang_cache', where: 'id = 1');
+    expect(rows.single['ton_kho_may_chu'], 4);
+  });
+
+  test(
+    'giamTonKhoQuaTang leaves unlimited stock (negative) untouched',
+    () async {
+      final qt = QuaTang(
+        id: 1,
+        ten: 'Keo',
+        giaDiem: 3,
+        tonKho: -1,
+        anhUrl: null,
+      );
+      await db.insert('qua_tang_cache', qt.toCacheRow());
+
+      await repo.giamTonKhoQuaTang(1);
+
+      final rows = await db.query('qua_tang_cache', where: 'id = 1');
+      expect(rows.single['ton_kho_may_chu'], -1);
+    },
+  );
 }

--- a/mobile/test/sync_engine_test.dart
+++ b/mobile/test/sync_engine_test.dart
@@ -1,0 +1,150 @@
+import 'package:dclass_mobile/api_client.dart';
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/outbox/hanh_dong_cho.dart';
+import 'package:dclass_mobile/outbox/outbox_repository.dart';
+import 'package:dclass_mobile/repositories/danh_muc_repository.dart';
+import 'package:dclass_mobile/sync/sync_engine.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'fakes/fake_diem_api.dart';
+
+HanhDongCho _hanhDongCongDiem({
+  required String clientActionId,
+  int hocSinhId = 1,
+}) {
+  return HanhDongCho(
+    clientActionId: clientActionId,
+    loai: LoaiHanhDong.congDiem,
+    hocSinhId: hocSinhId,
+    lyDoId: 1,
+    taoLuc: DateTime.now().toIso8601String(),
+  );
+}
+
+void main() {
+  late FakeDiemApi api;
+  late Database db;
+  late OutboxRepository outbox;
+  late DanhMucRepository danhMuc;
+  late SyncEngine engine;
+
+  setUp(() async {
+    api = FakeDiemApi();
+    db = await openAppDatabase(path: inMemoryDatabasePath);
+    outbox = OutboxRepository(db);
+    danhMuc = DanhMucRepository(api: api, db: db);
+    engine = SyncEngine(api: api, outbox: outbox, danhMuc: danhMuc);
+  });
+
+  test('replays queued actions sequentially, in insertion order', () async {
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-2'));
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-3'));
+    api.hangDoiKetQua.addAll([
+      {'so_du': 1},
+      {'so_du': 2},
+      {'so_du': 3},
+    ]);
+
+    await engine.chaySync();
+
+    expect(api.lenhDaGoi, ['congDiem:ca-1', 'congDiem:ca-2', 'congDiem:ca-3']);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test('success reconciles the cached balance from the response', () async {
+    await db.insert('hoc_sinh_cache', {
+      'id': 1,
+      'ho_ten': 'An',
+      'so_du_may_chu': 0,
+    });
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    api.hangDoiKetQua.add({'so_du': 42});
+
+    await engine.chaySync();
+
+    final rows = await db.query('hoc_sinh_cache', where: 'id = 1');
+    expect(rows.single['so_du_may_chu'], 42);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test(
+    'a permanent failure is marked loi_vinh_vien and the batch continues',
+    () async {
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-2'));
+      api.hangDoiKetQua.addAll([
+        ApiException('het_hang'),
+        {'so_du': 9},
+      ]);
+
+      await engine.chaySync();
+
+      expect(api.lenhDaGoi, ['congDiem:ca-1', 'congDiem:ca-2']);
+      final loi = await outbox.layDanhSachLoiVinhVien();
+      expect(loi.single.clientActionId, 'ca-1');
+      expect(loi.single.loiMa, 'het_hang');
+      expect(await outbox.layDanhSachChoXuLy(), isEmpty); // ca-2 applied
+    },
+  );
+
+  test(
+    'a transient failure re-queues the item and halts the rest of the batch',
+    () async {
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-2'));
+      api.hangDoiKetQua.add(Exception('SocketException: mat ket noi'));
+      // Only one scripted result: proves ca-2 is never attempted.
+
+      await engine.chaySync();
+
+      expect(api.lenhDaGoi, ['congDiem:ca-1']); // ca-2 not attempted
+      final choXuLy = await outbox.layDanhSachChoXuLy();
+      expect(choXuLy.map((e) => e.clientActionId), ['ca-1', 'ca-2']);
+      expect(choXuLy.first.trangThai, TrangThaiHanhDong.choXuLy);
+      expect(choXuLy.first.soLanThu, 1);
+      expect(choXuLy.last.soLanThu, 0); // untouched
+    },
+  );
+
+  test('a retried action reuses the same client_action_id', () async {
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    api.hangDoiKetQua.add(Exception('timeout'));
+    await engine.chaySync(); // fails transiently, re-queued
+
+    api.hangDoiKetQua.add({'so_du': 5});
+    await engine.chaySync(); // retried
+
+    expect(api.lenhDaGoi, ['congDiem:ca-1', 'congDiem:ca-1']);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test('concurrent chaySync calls collapse into a single pass', () async {
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    api.hangDoiKetQua.add({'so_du': 1});
+
+    final f1 = engine.chaySync();
+    final f2 = engine.chaySync();
+    await Future.wait([f1, f2]);
+
+    expect(api.lenhDaGoi, hasLength(1));
+  });
+
+  test(
+    'a leftover dang_gui row is swept back to pending on the next run',
+    () async {
+      final id = await outbox.themMoi(
+        _hanhDongCongDiem(clientActionId: 'ca-1'),
+      );
+      await outbox.danDauDangGui(id); // simulate an app kill mid-send
+
+      api.hangDoiKetQua.add({'so_du': 7});
+      await engine.chaySync();
+
+      expect(api.lenhDaGoi, ['congDiem:ca-1']);
+      expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Phase 3 of the approved offline+sync plan. **Stacked on #86** (Phase 2, itself stacked on #85 → #84). Merge order: #84 → #85 → #86 → this one → `main`.

- `SyncEngine` (`sync/sync_engine.dart`) replays the outbox strictly in insertion order:
  - startup sweep resets any leftover `dang_gui` row (safe via the server's `client_action_id` idempotency)
  - success reconciles the cached balance/stock from the response and deletes the outbox row
  - a **permanent** failure is marked `loi_vinh_vien` and **the batch continues** - a failed call makes no server-side state change, so later items still see real, unperturbed server state
  - a **transient** failure re-queues the item (attempt count incremented) and **halts the rest of the run** - this is the one place order must not be skipped over, since a later item running before an unresolved earlier one would break the replay-in-order guarantee
  - concurrent `chaySync()` calls collapse into one pass via a single in-flight `Future`
- Triggers are foreground-only by design (no background service, per the plan's explicit scope call): connectivity regained (`sync/connectivity_watcher.dart`), app resume (`sync/app_lifecycle_sync_trigger.dart`), and pull-to-refresh (`students_screen.dart`).
- `phien_dang_nhap.dart` (new): consolidates the repository/engine construction and trigger wiring both entry points (`main.dart` cold start, `login_screen.dart` fresh login) need identically - was about to become duplicated setup in both files.
- `danh_muc_repository.dart` gains `capNhatSoDuHocSinh`/`giamTonKhoQuaTang` for the sync engine to call after a confirmed server response.

## Test plan
- [ ] `CI Flutter (mobile)` passes — `sync_engine_test.dart` covers ordering, success reconciliation, permanent-vs-transient handling (including that a transient failure halts the batch while a permanent one doesn't), idempotent retry (same `client_action_id` reused), re-entrancy, and the `dang_gui` sweep
- [ ] Manual: queue a couple of add-points actions while offline (airplane mode), confirm they show "queued" and nothing is sent; re-enable connectivity, confirm they sync automatically without touching the app; confirm `api/diem.php?hanh_dong=lich_su` on the server shows exactly one ledger row per action (no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)