### PR TITLE
mobile: Phase 4 redeem-gift flow, sync status UI, failed-actions review

### DIFF
--- a/mobile/lib/screens/failed_actions_screen.dart
+++ b/mobile/lib/screens/failed_actions_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+import '../outbox/hanh_dong_cho.dart';
+import '../outbox/outbox_repository.dart';
+import '../repositories/danh_muc_repository.dart';
+import '../sync/sync_engine.dart';
+import '../utils/thong_bao_loi.dart';
+
+class _DuLieuManHinh {
+  _DuLieuManHinh(this.danhSach, this.tenTheoId);
+  final List<HanhDongCho> danhSach;
+  final Map<int, String> tenTheoId;
+}
+
+/// Lets a teacher review point actions that failed permanently (an inactive
+/// reason, insufficient balance, an out-of-stock gift, ...) - see
+/// SyncEngine's error classification. These are never auto-retried; a
+/// teacher discards them or retries manually once whatever caused the
+/// failure might have changed.
+class FailedActionsScreen extends StatefulWidget {
+  const FailedActionsScreen({
+    super.key,
+    required this.outbox,
+    required this.syncEngine,
+    required this.danhMuc,
+  });
+
+  final OutboxRepository outbox;
+  final SyncEngine syncEngine;
+  final DanhMucRepository danhMuc;
+
+  @override
+  State<FailedActionsScreen> createState() => _FailedActionsScreenState();
+}
+
+class _FailedActionsScreenState extends State<FailedActionsScreen> {
+  late Future<_DuLieuManHinh> _duLieu;
+
+  @override
+  void initState() {
+    super.initState();
+    _duLieu = _nap();
+  }
+
+  Future<_DuLieuManHinh> _nap() async {
+    final danhSach = await widget.outbox.layDanhSachLoiVinhVien();
+    final hocSinh = await widget.danhMuc.danhSachHocSinh();
+    final tenTheoId = {for (final hs in hocSinh) hs.id: hs.hoTen};
+    return _DuLieuManHinh(danhSach, tenTheoId);
+  }
+
+  void _lamMoi() => setState(() => _duLieu = _nap());
+
+  Future<void> _thuLai(int id) async {
+    await widget.outbox.datLaiChoXuLy(id);
+    await widget.syncEngine.chaySync();
+    _lamMoi();
+  }
+
+  Future<void> _xoa(int id) async {
+    await widget.outbox.xoa(id);
+    _lamMoi();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Thao tác lỗi')),
+      body: FutureBuilder<_DuLieuManHinh>(
+        future: _duLieu,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final duLieu = snap.data!;
+          if (duLieu.danhSach.isEmpty) {
+            return const Center(child: Text('Không có thao tác lỗi nào'));
+          }
+          return ListView.separated(
+            itemCount: duLieu.danhSach.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, i) {
+              final hd = duLieu.danhSach[i];
+              final ten =
+                  duLieu.tenTheoId[hd.hocSinhId] ?? 'Học sinh #${hd.hocSinhId}';
+              return ListTile(
+                title: Text(ten),
+                subtitle: Text(thongBaoLoi(hd.loiMa)),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.refresh),
+                      tooltip: 'Thử lại',
+                      onPressed: () => _thuLai(hd.id!),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Xóa',
+                      onPressed: () => _xoa(hd.id!),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/redeem_gift_screen.dart
+++ b/mobile/lib/screens/redeem_gift_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import '../models/qua_tang.dart';
+
+/// Bottom sheet to pick a gift to redeem - mirrors the reason-picker sheet
+/// used by the add-points flow in students_screen.dart.
+Future<QuaTang?> chonQuaTangDeDoi(BuildContext context, List<QuaTang> ds) {
+  return showModalBottomSheet<QuaTang>(
+    context: context,
+    builder: (ctx) => SafeArea(
+      child: ListView(
+        shrinkWrap: true,
+        children: ds
+            .map(
+              (qt) => ListTile(
+                leading: const Icon(Icons.card_giftcard),
+                title: Text(qt.ten),
+                subtitle: Text('Còn ${qt.tonKho} - ${qt.giaDiem} điểm'),
+                enabled: qt.tonKho != 0,
+                onTap: () => Navigator.of(ctx).pop(qt),
+              ),
+            )
+            .toList(),
+      ),
+    ),
+  );
+}

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 
 import '../models/hoc_sinh.dart';
 import '../models/ly_do.dart';
+import '../models/qua_tang.dart';
 import '../repositories/danh_muc_repository.dart';
 import '../repositories/diem_repository.dart';
 import '../sync/sync_engine.dart';
+import '../widgets/sync_status_badge.dart';
+import 'failed_actions_screen.dart';
+import 'redeem_gift_screen.dart';
 
 /// Student list with a quick "add points" action per row - the core
 /// in-class flow the mobile app exists for (web stays the tool for
@@ -37,6 +41,35 @@ class _StudentsScreenState extends State<StudentsScreen> {
     await widget.syncEngine.chaySync();
     setState(() => _hocSinh = widget.danhMuc.danhSachHocSinh());
     await _hocSinh;
+  }
+
+  Future<void> _chonHanhDong(HocSinh hs) async {
+    final hanhDong = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.add_circle_outline),
+              title: const Text('Cộng điểm...'),
+              onTap: () => Navigator.of(ctx).pop('cong_diem'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.card_giftcard),
+              title: const Text('Đổi quà...'),
+              onTap: () => Navigator.of(ctx).pop('doi_qua'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (!mounted || hanhDong == null) return;
+    if (hanhDong == 'cong_diem') {
+      await _chonLyDoVaCongDiem(hs);
+    } else {
+      await _chonQuaVaDoiDiem(hs);
+    }
   }
 
   Future<void> _chonLyDoVaCongDiem(HocSinh hs) async {
@@ -92,10 +125,67 @@ class _StudentsScreenState extends State<StudentsScreen> {
     }
   }
 
+  Future<void> _chonQuaVaDoiDiem(HocSinh hs) async {
+    List<QuaTang> quaTangList;
+    try {
+      quaTangList = await widget.danhMuc.danhSachQuaTang();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Lỗi tải quà: $e')));
+      return;
+    }
+    if (!mounted) return;
+    final quaTang = await chonQuaTangDeDoi(context, quaTangList);
+    if (quaTang == null) return;
+    try {
+      final ketQua = await widget.diem.themDoiQua(
+        hocSinhId: hs.id,
+        quaTangId: quaTang.id,
+      );
+      if (!mounted) return;
+      final thongBao = ketQua == KetQuaGhiDiem.daApDungNgay
+          ? 'Đã đổi ${quaTang.ten} cho ${hs.hoTen}'
+          : 'Đã ghi nhận cho ${hs.hoTen} - sẽ đồng bộ khi có mạng';
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(thongBao)));
+      await _lamMoi();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Lỗi: $e')));
+    }
+  }
+
+  void _moThaoTacLoi() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FailedActionsScreen(
+          outbox: widget.diem.outbox,
+          syncEngine: widget.syncEngine,
+          danhMuc: widget.danhMuc,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Học sinh')),
+      appBar: AppBar(
+        title: const Text('Học sinh'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.error_outline),
+            tooltip: 'Thao tác lỗi',
+            onPressed: _moThaoTacLoi,
+          ),
+          SyncStatusBadge(syncEngine: widget.syncEngine),
+        ],
+      ),
       body: RefreshIndicator(
         onRefresh: _lamMoi,
         child: FutureBuilder<List<HocSinh>>(
@@ -120,7 +210,7 @@ class _StudentsScreenState extends State<StudentsScreen> {
                   title: Text(hs.hoTen),
                   subtitle: Text(hs.tenLop ?? ''),
                   trailing: Text('${hs.soDu} điểm'),
-                  onTap: () => _chonLyDoVaCongDiem(hs),
+                  onTap: () => _chonHanhDong(hs),
                 );
               },
             );

--- a/mobile/lib/utils/thong_bao_loi.dart
+++ b/mobile/lib/utils/thong_bao_loi.dart
@@ -1,0 +1,22 @@
+/// Friendly Vietnamese message for a queued action's stored error code
+/// (`HanhDongCho.loiMa`) - mirrors the server's error strings (see
+/// `lib/diem_nghiep_vu.php`) or an `ApiClient`-synthesized `loi_http_<code>`.
+String thongBaoLoi(String? maLoi) {
+  switch (maLoi) {
+    case 'het_hang':
+      return 'Quà đã hết hàng';
+    case 'khong_du_diem':
+      return 'Học sinh không đủ điểm để đổi quà';
+    case 'ly_do_khong_hop_le':
+      return 'Lý do không còn hoạt động';
+    case 'qua_khong_hop_le':
+      return 'Quà không còn hoạt động';
+    case 'khong_du_quyen':
+      return 'Không có quyền trên học sinh này';
+    case 'thieu_thong_tin':
+      return 'Thiếu thông tin cần thiết';
+    case 'loi_http_401':
+      return 'Token không hợp lệ, vui lòng đăng nhập lại';
+  }
+  return maLoi == null ? 'Lỗi không xác định' : 'Lỗi: $maLoi';
+}

--- a/mobile/lib/widgets/sync_status_badge.dart
+++ b/mobile/lib/widgets/sync_status_badge.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../sync/connectivity_watcher.dart';
+import '../sync/sync_engine.dart';
+
+/// AppBar action showing offline/syncing/pending-count status; tapping it
+/// triggers a manual sync.
+class SyncStatusBadge extends StatefulWidget {
+  const SyncStatusBadge({super.key, required this.syncEngine});
+
+  final SyncEngine syncEngine;
+
+  @override
+  State<SyncStatusBadge> createState() => _SyncStatusBadgeState();
+}
+
+class _SyncStatusBadgeState extends State<SyncStatusBadge> {
+  final _ketNoi = ConnectivityWatcher();
+  bool _coKetNoi = true;
+  StreamSubscription<bool>? _dangKy;
+
+  @override
+  void initState() {
+    super.initState();
+    _ketNoi.coKetNoiHienTai().then((gt) {
+      if (mounted) setState(() => _coKetNoi = gt);
+    });
+    _dangKy = _ketNoi.thayDoi.listen((gt) {
+      if (mounted) setState(() => _coKetNoi = gt);
+    });
+  }
+
+  @override
+  void dispose() {
+    _dangKy?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.syncEngine,
+      builder: (context, _) {
+        if (widget.syncEngine.dangDongBo) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          );
+        }
+        final soLuong = widget.syncEngine.soLuongChoXuLy;
+        final Widget icon;
+        final String nhan;
+        if (!_coKetNoi) {
+          icon = const Icon(Icons.cloud_off);
+          nhan = 'Ngoại tuyến';
+        } else if (soLuong > 0) {
+          icon = Badge(
+            label: Text('$soLuong'),
+            child: const Icon(Icons.cloud_upload),
+          );
+          nhan = '$soLuong thao tác chưa đồng bộ - nhấn để đồng bộ ngay';
+        } else {
+          icon = const Icon(Icons.cloud_done);
+          nhan = 'Đã đồng bộ';
+        }
+        return IconButton(
+          icon: icon,
+          tooltip: nhan,
+          onPressed: () => widget.syncEngine.chaySync(),
+        );
+      },
+    );
+  }
+}

--- a/mobile/test/thong_bao_loi_test.dart
+++ b/mobile/test/thong_bao_loi_test.dart
@@ -1,0 +1,19 @@
+import 'package:dclass_mobile/utils/thong_bao_loi.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('maps known server error codes to Vietnamese messages', () {
+    expect(thongBaoLoi('het_hang'), contains('hết hàng'));
+    expect(thongBaoLoi('khong_du_diem'), contains('không đủ điểm'));
+    expect(thongBaoLoi('ly_do_khong_hop_le'), contains('Lý do'));
+    expect(thongBaoLoi('loi_http_401'), contains('đăng nhập lại'));
+  });
+
+  test('falls back to a generic message for an unrecognized code', () {
+    expect(thongBaoLoi('loi_la'), 'Lỗi: loi_la');
+  });
+
+  test('handles a null error code', () {
+    expect(thongBaoLoi(null), 'Lỗi không xác định');
+  });
+}


### PR DESCRIPTION
## Summary
Phase 4 of the approved offline+sync plan. **Stacked on #87** (Phase 3, itself stacked on #86 → #85 → #84). Merge order: #84 → #85 → #86 → #87 → this one → `main`.

- `redeem_gift_screen.dart`: gift-picker bottom sheet symmetric to the existing reason-picker. Disabled for an out-of-stock gift (`ton_kho == 0`); a negative `ton_kho` means unlimited and stays enabled, matching `quy_doi_qua_tang`'s own rule on the server.
- `students_screen.dart`: tapping a student now opens an action sheet ("Cộng điểm..." / "Đổi quà...") instead of going straight to the reason picker. The redeem flow mirrors add-points (tries the network via `DiemRepository.themDoiQua`, distinguishes "applied now" from "queued, will sync when possible").
- `widgets/sync_status_badge.dart`: AppBar action showing offline/syncing/pending-count state (via `SyncEngine` + `ConnectivityWatcher`); tapping it triggers a manual sync.
- `screens/failed_actions_screen.dart`: reviews permanently-failed queued actions (`utils/thong_bao_loi.dart` maps the stored error code to a Vietnamese message), with per-row discard or manual retry - never auto-retried, since a permanent failure needs something to actually change first (a reason reactivated, restocked, etc.).

This branch's base (#87) now also carries a real bugfix caught while wiring this up: `giamTonKhoQuaTang` was clamping stock at 0 with `MAX(x-1, 0)`, which would've turned an "unlimited" (negative) gift's stock into 0 - looking out of stock - after a single redeem.

## Test plan
- [ ] `CI Flutter (mobile)` passes — `thong_bao_loi_test.dart` (error-code-to-message mapping)
- [ ] Manual: tap a student, confirm the action sheet offers both options; redeem a gift with stock, confirm it decrements; try redeeming an out-of-stock gift, confirm it's shown disabled; go offline, queue a couple of actions, confirm the AppBar badge shows the pending count and an offline icon; open "Thao tác lỗi" with a permanently-failed action queued (e.g. redeem more than the balance allows), confirm it lists with the right message and discard/retry both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)