### PR TITLE
mobile: Phase 5 secure token storage migration

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,9 +6,9 @@ import 'api_client.dart';
 import 'db/app_database.dart';
 import 'phien_dang_nhap.dart';
 import 'screens/login_screen.dart';
+import 'secure_token_storage.dart';
 
 const String prefsBaseUrl = 'base_url';
-const String prefsToken = 'api_token';
 
 void main() {
   runApp(const DClassApp());
@@ -50,7 +50,7 @@ class _KhoiDongState extends State<_KhoiDong> {
   Future<void> _nap() async {
     final prefs = await SharedPreferences.getInstance();
     final baseUrl = prefs.getString(prefsBaseUrl);
-    final token = prefs.getString(prefsToken);
+    final token = await docToken();
     if (baseUrl == null || token == null) {
       setState(() => _dangTai = false);
       return;

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -5,6 +5,7 @@ import '../api_client.dart';
 import '../db/app_database.dart';
 import '../main.dart';
 import '../phien_dang_nhap.dart';
+import '../secure_token_storage.dart';
 
 /// Lets a teacher point the app at their DClass server and paste the API
 /// token generated from cau_hinh.php's "Tài khoản" tab (shown there as text
@@ -43,7 +44,7 @@ class _LoginScreenState extends State<LoginScreen> {
       await client.danhSachHocSinh();
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(prefsBaseUrl, baseUrl);
-      await prefs.setString(prefsToken, token);
+      await luuToken(token);
       final db = await openAppDatabase();
       if (!mounted) return;
       Navigator.of(context).pushReplacement(

--- a/mobile/lib/secure_token_storage.dart
+++ b/mobile/lib/secure_token_storage.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _khoaToken = 'api_token';
+
+const _storage = FlutterSecureStorage();
+
+/// Reads the saved Bearer token from secure storage (Keychain/Keystore).
+///
+/// The token is a single-active-credential secret equivalent to a password
+/// for a teacher's real student roster - `shared_preferences` (plain,
+/// unencrypted storage on both platforms) is the wrong place to keep it.
+/// On first read, migrates a legacy plaintext copy left over from before
+/// this file existed, then deletes it, so an existing install isn't
+/// silently logged out.
+Future<String?> docToken() async {
+  final tuAnToan = await _storage.read(key: _khoaToken);
+  if (tuAnToan != null) return tuAnToan;
+
+  final prefs = await SharedPreferences.getInstance();
+  final cu = prefs.getString(_khoaToken);
+  if (cu != null) {
+    await _storage.write(key: _khoaToken, value: cu);
+    await prefs.remove(_khoaToken);
+    return cu;
+  }
+  return null;
+}
+
+Future<void> luuToken(String token) {
+  return _storage.write(key: _khoaToken, value: token);
+}
+
+Future<void> xoaToken() {
+  return _storage.delete(key: _khoaToken);
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -22,6 +22,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^4.0.0
   sqflite_common_ffi: ^2.3.0
+  flutter_secure_storage_platform_interface: ^1.1.2
 
 flutter:
   uses-material-design: true

--- a/mobile/test/fakes/fake_secure_storage_platform.dart
+++ b/mobile/test/fakes/fake_secure_storage_platform.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+
+/// In-memory fake for [FlutterSecureStoragePlatform], registered in widget
+/// tests the same way `SharedPreferences.setMockInitialValues({})` fakes
+/// shared_preferences - there's no bundled mock equivalent for
+/// flutter_secure_storage, so this is hand-written against the small
+/// platform-interface contract.
+class FakeSecureStoragePlatform extends FlutterSecureStoragePlatform {
+  final Map<String, String> _luuTru = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    _luuTru[key] = value;
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    return _luuTru[key];
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    return _luuTru.containsKey(key);
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    _luuTru.remove(key);
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) async {
+    return Map.of(_luuTru);
+  }
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async {
+    _luuTru.clear();
+  }
+}

--- a/mobile/test/secure_token_storage_test.dart
+++ b/mobile/test/secure_token_storage_test.dart
@@ -1,0 +1,45 @@
+import 'package:dclass_mobile/secure_token_storage.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'fakes/fake_secure_storage_platform.dart';
+
+void main() {
+  setUp(() {
+    FlutterSecureStoragePlatform.instance = FakeSecureStoragePlatform();
+  });
+
+  test('no token saved anywhere: docToken returns null', () async {
+    SharedPreferences.setMockInitialValues({});
+    expect(await docToken(), isNull);
+  });
+
+  test('luuToken/docToken round-trip through secure storage', () async {
+    SharedPreferences.setMockInitialValues({});
+    await luuToken('token-moi');
+    expect(await docToken(), 'token-moi');
+  });
+
+  test(
+    'migrates a legacy plaintext token from shared_preferences once',
+    () async {
+      SharedPreferences.setMockInitialValues({'api_token': 'token-cu'});
+
+      final token = await docToken();
+      expect(token, 'token-cu');
+
+      // Migrated into secure storage and removed from shared_preferences.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('api_token'), isNull);
+      expect(await docToken(), 'token-cu'); // now served from secure storage
+    },
+  );
+
+  test('xoaToken removes the saved token', () async {
+    SharedPreferences.setMockInitialValues({});
+    await luuToken('token-moi');
+    await xoaToken();
+    expect(await docToken(), isNull);
+  });
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,11 +1,15 @@
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dclass_mobile/main.dart';
 
+import 'fakes/fake_secure_storage_platform.dart';
+
 void main() {
   testWidgets('shows the login screen when no token is saved', (tester) async {
     SharedPreferences.setMockInitialValues({});
+    FlutterSecureStoragePlatform.instance = FakeSecureStoragePlatform();
     await tester.pumpWidget(const DClassApp());
     await tester.pump();
     expect(find.text('Kết nối DClass'), findsOneWidget);


### PR DESCRIPTION
## Summary
Phase 5 (final phase) of the approved offline+sync plan. **Stacked on #88** (Phase 4, itself stacked on #87 → #86 → #85 → #84). Merge order: #84 → #85 → #86 → #87 → #88 → this one → `main`.

- The Bearer token is a single-active-credential secret equivalent to a password for a teacher's real student roster (one active token per teacher; regenerating invalidates the previous one - see `thu_xac_thuc_bang_token` in `lib/tro_giup.php`). `shared_preferences` stores it as unencrypted plaintext on both platforms; moved to `flutter_secure_storage` (Keystore/Keychain-backed) instead. `base_url` stays in `shared_preferences` - it isn't sensitive.
- `secure_token_storage.dart` wraps read/write/delete and does a **one-time migration**: on first read, a legacy plaintext token left in `shared_preferences` (from before this file existed) is moved into secure storage and the plaintext copy deleted, so an existing install isn't silently logged out.
- `flutter_secure_storage_platform_interface` added as a dev dependency, pinned to `^1.1.2` - confirmed against the actually-published `flutter_secure_storage ^9.0.0` dependency tree (not guessed), so tests can register `FakeSecureStoragePlatform` (in-memory hand-written fake, same idea as `SharedPreferences.setMockInitialValues({})`).
- `widget_test.dart` needed the fake too - `_KhoiDong._nap()` now calls `docToken()` unconditionally on every launch, including the "no token saved" path the existing test exercises.

## Test plan
- [ ] `CI Flutter (mobile)` passes — `secure_token_storage_test.dart` (round-trip, legacy-plaintext migration, delete) and the updated `widget_test.dart`
- [ ] Manual: fresh install, log in, confirm the app still routes straight to the student list on relaunch; simulate an existing install by seeding `shared_preferences`' `api_token` key directly and confirm the app migrates it in and still logs in successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)