### PR TITLE
mobile: land Phases 1-5 of the offline+sync layer into main

### DIFF
--- a/mobile/lib/loi_phan_loai.dart
+++ b/mobile/lib/loi_phan_loai.dart
@@ -1,0 +1,37 @@
+import 'api_client.dart';
+
+/// Server error codes (see `lib/diem_nghiep_vu.php`) that are permanent -
+/// retrying the exact same request won't help unless something changes
+/// server-side first (a reason gets reactivated, stock gets restocked...).
+const _maLoiVinhVien = {
+  'ly_do_khong_hop_le',
+  'khong_du_quyen',
+  'qua_khong_hop_le',
+  'het_hang',
+  'khong_du_diem',
+  'thieu_thong_tin',
+};
+
+/// Whether [loi] is worth retrying later unchanged (network hiccup, server
+/// briefly down) as opposed to a permanent/business failure that needs the
+/// user - or a server-side change - to resolve. Shared by DiemRepository's
+/// immediate-attempt fallback and the sync engine's replay loop so both
+/// classify errors identically.
+bool laLoiTamThoi(Object loi) {
+  if (loi is ApiException) {
+    final ma = loi.thongBao;
+    if (_maLoiVinhVien.contains(ma)) return false;
+    if (ma.startsWith('loi_http_')) {
+      final maSo = int.tryParse(ma.substring('loi_http_'.length));
+      if (maSo != null) {
+        // Timeouts, rate-limiting, and any 5xx are worth retrying; other
+        // 4xx (401 bad/revoked token, 404, ...) are not.
+        return maSo == 408 || maSo == 429 || maSo >= 500;
+      }
+    }
+    return false; // unrecognized ApiException message: treat as permanent
+  }
+  // Anything else (SocketException, TimeoutException, http.ClientException,
+  // ...) is a network-level failure - always transient.
+  return true;
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite/sqflite.dart';
 
 import 'api_client.dart';
+import 'db/app_database.dart';
+import 'phien_dang_nhap.dart';
 import 'screens/login_screen.dart';
-import 'screens/students_screen.dart';
+import 'secure_token_storage.dart';
 
 const String prefsBaseUrl = 'base_url';
-const String prefsToken = 'api_token';
 
 void main() {
   runApp(const DClassApp());
@@ -36,6 +38,7 @@ class _KhoiDong extends StatefulWidget {
 
 class _KhoiDongState extends State<_KhoiDong> {
   ApiClient? _client;
+  Database? _db;
   bool _dangTai = true;
 
   @override
@@ -47,11 +50,16 @@ class _KhoiDongState extends State<_KhoiDong> {
   Future<void> _nap() async {
     final prefs = await SharedPreferences.getInstance();
     final baseUrl = prefs.getString(prefsBaseUrl);
-    final token = prefs.getString(prefsToken);
+    final token = await docToken();
+    if (baseUrl == null || token == null) {
+      setState(() => _dangTai = false);
+      return;
+    }
+    final client = ApiClient(baseUrl: baseUrl, token: token);
+    final db = await openAppDatabase();
     setState(() {
-      _client = (baseUrl != null && token != null)
-          ? ApiClient(baseUrl: baseUrl, token: token)
-          : null;
+      _client = client;
+      _db = db;
       _dangTai = false;
     });
   }
@@ -61,8 +69,8 @@ class _KhoiDongState extends State<_KhoiDong> {
     if (_dangTai) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    return _client == null
+    return (_client == null || _db == null)
         ? const LoginScreen()
-        : StudentsScreen(client: _client!);
+        : PhienDangNhap(client: _client!, db: _db!);
   }
 }

--- a/mobile/lib/models/hoc_sinh.dart
+++ b/mobile/lib/models/hoc_sinh.dart
@@ -25,4 +25,28 @@ class HocSinh {
       soDu: (json['so_du'] as num?)?.toInt() ?? 0,
     );
   }
+
+  /// Row shape for `hoc_sinh_cache` (see `lib/db/app_database.dart`).
+  factory HocSinh.fromCacheRow(Map<String, Object?> row) {
+    return HocSinh(
+      id: row['id'] as int,
+      ma: row['ma'] as String?,
+      hoTen: row['ho_ten'] as String? ?? '',
+      lopHocId: row['lop_hoc_id'] as int?,
+      tenLop: row['ten_lop'] as String?,
+      soDu: (row['so_du_may_chu'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, Object?> toCacheRow() {
+    return {
+      'id': id,
+      'ma': ma,
+      'ho_ten': hoTen,
+      'lop_hoc_id': lopHocId,
+      'ten_lop': tenLop,
+      'so_du_may_chu': soDu,
+      'cap_nhat_luc': DateTime.now().toIso8601String(),
+    };
+  }
 }

--- a/mobile/lib/models/ly_do.dart
+++ b/mobile/lib/models/ly_do.dart
@@ -12,4 +12,22 @@ class LyDo {
       bienDiem: (json['bien_diem'] as num?)?.toInt() ?? 0,
     );
   }
+
+  /// Row shape for `ly_do_cache` (see `lib/db/app_database.dart`).
+  factory LyDo.fromCacheRow(Map<String, Object?> row) {
+    return LyDo(
+      id: row['id'] as int,
+      tieuDe: row['tieu_de'] as String? ?? '',
+      bienDiem: (row['bien_diem'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  Map<String, Object?> toCacheRow() {
+    return {
+      'id': id,
+      'tieu_de': tieuDe,
+      'bien_diem': bienDiem,
+      'cap_nhat_luc': DateTime.now().toIso8601String(),
+    };
+  }
 }

--- a/mobile/lib/models/qua_tang.dart
+++ b/mobile/lib/models/qua_tang.dart
@@ -22,4 +22,26 @@ class QuaTang {
       anhUrl: json['anh_url'] as String?,
     );
   }
+
+  /// Row shape for `qua_tang_cache` (see `lib/db/app_database.dart`).
+  factory QuaTang.fromCacheRow(Map<String, Object?> row) {
+    return QuaTang(
+      id: row['id'] as int,
+      ten: row['ten'] as String? ?? '',
+      giaDiem: (row['gia_diem'] as num?)?.toInt() ?? 0,
+      tonKho: (row['ton_kho_may_chu'] as num?)?.toInt() ?? 0,
+      anhUrl: row['anh_url'] as String?,
+    );
+  }
+
+  Map<String, Object?> toCacheRow() {
+    return {
+      'id': id,
+      'ten': ten,
+      'gia_diem': giaDiem,
+      'ton_kho_may_chu': tonKho,
+      'anh_url': anhUrl,
+      'cap_nhat_luc': DateTime.now().toIso8601String(),
+    };
+  }
 }

--- a/mobile/lib/outbox/hanh_dong_cho.dart
+++ b/mobile/lib/outbox/hanh_dong_cho.dart
@@ -1,0 +1,112 @@
+/// What kind of point transaction a queued action represents - matches the
+/// server's `so_cai_diem.loai` values ('CONG_DIEM' / 'DOI_DIEM').
+enum LoaiHanhDong {
+  congDiem,
+  doiQua;
+
+  String get gtri => this == LoaiHanhDong.congDiem ? 'CONG_DIEM' : 'DOI_DIEM';
+
+  static LoaiHanhDong tuChuoi(String s) {
+    return s == 'DOI_DIEM' ? LoaiHanhDong.doiQua : LoaiHanhDong.congDiem;
+  }
+}
+
+/// Lifecycle state of a queued action. See `mobile/lib/db/app_database.dart`
+/// for the `hang_doi_thao_tac.trang_thai` CHECK constraint this mirrors.
+enum TrangThaiHanhDong {
+  choXuLy,
+  dangGui,
+  loiVinhVien;
+
+  String get gtri {
+    switch (this) {
+      case TrangThaiHanhDong.choXuLy:
+        return 'cho_xu_ly';
+      case TrangThaiHanhDong.dangGui:
+        return 'dang_gui';
+      case TrangThaiHanhDong.loiVinhVien:
+        return 'loi_vinh_vien';
+    }
+  }
+
+  static TrangThaiHanhDong tuChuoi(String s) {
+    switch (s) {
+      case 'dang_gui':
+        return TrangThaiHanhDong.dangGui;
+      case 'loi_vinh_vien':
+        return TrangThaiHanhDong.loiVinhVien;
+      default:
+        return TrangThaiHanhDong.choXuLy;
+    }
+  }
+}
+
+/// A queued offline point action, one row of `hang_doi_thao_tac`. [id] is
+/// null until the row has been inserted (sqlite assigns it, and it's the
+/// strict FIFO ordering key - see the sync engine).
+class HanhDongCho {
+  final int? id;
+  final String clientActionId;
+  final LoaiHanhDong loai;
+  final int hocSinhId;
+  final int? lyDoId;
+  final int? quaTangId;
+  final String ghiChu;
+  final TrangThaiHanhDong trangThai;
+  final String? loiMa;
+  final int soLanThu;
+  final String taoLuc;
+  final String? capNhatLuc;
+
+  HanhDongCho({
+    this.id,
+    required this.clientActionId,
+    required this.loai,
+    required this.hocSinhId,
+    this.lyDoId,
+    this.quaTangId,
+    this.ghiChu = '',
+    this.trangThai = TrangThaiHanhDong.choXuLy,
+    this.loiMa,
+    this.soLanThu = 0,
+    required this.taoLuc,
+    this.capNhatLuc,
+  });
+
+  factory HanhDongCho.fromRow(Map<String, Object?> row) {
+    return HanhDongCho(
+      id: row['id'] as int?,
+      clientActionId: row['client_action_id'] as String,
+      loai: LoaiHanhDong.tuChuoi(row['loai'] as String),
+      hocSinhId: row['hoc_sinh_id'] as int,
+      lyDoId: row['ly_do_id'] as int?,
+      quaTangId: row['qua_tang_id'] as int?,
+      ghiChu: row['ghi_chu'] as String? ?? '',
+      trangThai: TrangThaiHanhDong.tuChuoi(
+        row['trang_thai'] as String? ?? 'cho_xu_ly',
+      ),
+      loiMa: row['loi_ma'] as String?,
+      soLanThu: (row['so_lan_thu'] as num?)?.toInt() ?? 0,
+      taoLuc: row['tao_luc'] as String,
+      capNhatLuc: row['cap_nhat_luc'] as String?,
+    );
+  }
+
+  Map<String, Object?> toRow() {
+    final row = <String, Object?>{
+      'client_action_id': clientActionId,
+      'loai': loai.gtri,
+      'hoc_sinh_id': hocSinhId,
+      'ly_do_id': lyDoId,
+      'qua_tang_id': quaTangId,
+      'ghi_chu': ghiChu,
+      'trang_thai': trangThai.gtri,
+      'loi_ma': loiMa,
+      'so_lan_thu': soLanThu,
+      'tao_luc': taoLuc,
+      'cap_nhat_luc': capNhatLuc,
+    };
+    if (id != null) row['id'] = id;
+    return row;
+  }
+}

--- a/mobile/lib/outbox/outbox_repository.dart
+++ b/mobile/lib/outbox/outbox_repository.dart
@@ -1,0 +1,108 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'hanh_dong_cho.dart';
+
+const String _bang = 'hang_doi_thao_tac';
+
+/// Persists the queue of offline point actions and their lifecycle
+/// transitions. Ordering for replay is always the local autoincrement `id`
+/// (`ORDER BY id ASC`), not `tao_luc` - avoids any clock-skew concern and
+/// matches insertion order exactly for a single-writer, single-device app.
+class OutboxRepository {
+  OutboxRepository(this.db);
+  final Database db;
+
+  Future<int> themMoi(HanhDongCho hanhDong) {
+    return db.insert(_bang, hanhDong.toRow());
+  }
+
+  /// All actions still needing to be sent, oldest first. Excludes
+  /// permanently-failed actions - those are surfaced separately via
+  /// [layDanhSachLoiVinhVien] and never auto-retried.
+  Future<List<HanhDongCho>> layDanhSachChoXuLy() async {
+    final rows = await db.query(
+      _bang,
+      where: 'trang_thai != ?',
+      whereArgs: [TrangThaiHanhDong.loiVinhVien.gtri],
+      orderBy: 'id ASC',
+    );
+    return rows.map(HanhDongCho.fromRow).toList();
+  }
+
+  Future<List<HanhDongCho>> layDanhSachLoiVinhVien() async {
+    final rows = await db.query(
+      _bang,
+      where: 'trang_thai = ?',
+      whereArgs: [TrangThaiHanhDong.loiVinhVien.gtri],
+      orderBy: 'id ASC',
+    );
+    return rows.map(HanhDongCho.fromRow).toList();
+  }
+
+  Future<void> danDauDangGui(int id) {
+    return db.update(
+      _bang,
+      {
+        'trang_thai': TrangThaiHanhDong.dangGui.gtri,
+        'cap_nhat_luc': DateTime.now().toIso8601String(),
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<void> danhDauLoiVinhVien(int id, String maLoi) {
+    return db.update(
+      _bang,
+      {
+        'trang_thai': TrangThaiHanhDong.loiVinhVien.gtri,
+        'loi_ma': maLoi,
+        'cap_nhat_luc': DateTime.now().toIso8601String(),
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  /// Resets an action back to pending (incrementing its attempt count) -
+  /// used both for a transient-failure retry and for a user-initiated
+  /// "Thử lại" on a previously permanently-failed action.
+  Future<void> datLaiChoXuLy(int id) {
+    return db.rawUpdate(
+      'UPDATE $_bang SET trang_thai = ?, so_lan_thu = so_lan_thu + 1, '
+      'cap_nhat_luc = ? WHERE id = ?',
+      [TrangThaiHanhDong.choXuLy.gtri, DateTime.now().toIso8601String(), id],
+    );
+  }
+
+  /// Resets any action left `dang_gui` (in-flight) back to `cho_xu_ly` -
+  /// call once when the sync engine starts. Safe because the server's
+  /// `client_action_id` idempotency guarantees a resend either double-checks
+  /// harmlessly or applies fresh - see so_cai_diem's partial unique index.
+  Future<void> quetDangGuiConLai() {
+    return db.update(
+      _bang,
+      {'trang_thai': TrangThaiHanhDong.choXuLy.gtri},
+      where: 'trang_thai = ?',
+      whereArgs: [TrangThaiHanhDong.dangGui.gtri],
+    );
+  }
+
+  Future<int> demSoLuongChoXuLy() async {
+    final ketQua = await db.rawQuery(
+      'SELECT COUNT(*) AS c FROM $_bang WHERE trang_thai != ?',
+      [TrangThaiHanhDong.loiVinhVien.gtri],
+    );
+    return Sqflite.firstIntValue(ketQua) ?? 0;
+  }
+
+  /// Deletes a successfully-synced action - the server's own ledger
+  /// (`api/diem.php?hanh_dong=lich_su`) is the durable record, no need to
+  /// keep a local copy once it's confirmed applied.
+  Future<void> xoaSauKhiThanhCong(int id) => xoa(id);
+
+  /// User-initiated discard of a permanently-failed action.
+  Future<void> xoa(int id) {
+    return db.delete(_bang, where: 'id = ?', whereArgs: [id]);
+  }
+}

--- a/mobile/lib/phien_dang_nhap.dart
+++ b/mobile/lib/phien_dang_nhap.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:sqflite/sqflite.dart';
+
+import 'api_client.dart';
+import 'outbox/outbox_repository.dart';
+import 'repositories/danh_muc_repository.dart';
+import 'repositories/diem_repository.dart';
+import 'screens/students_screen.dart';
+import 'sync/app_lifecycle_sync_trigger.dart';
+import 'sync/connectivity_watcher.dart';
+import 'sync/sync_engine.dart';
+
+/// Everything a logged-in session needs: repositories, the sync engine, its
+/// connectivity + app-resume triggers, and the student list. Built once
+/// [client]/[db] are ready - both entry points (cold start via `main.dart`,
+/// and a fresh login via `login_screen.dart`) already have both in hand by
+/// the time they reach this widget.
+class PhienDangNhap extends StatefulWidget {
+  const PhienDangNhap({super.key, required this.client, required this.db});
+
+  final ApiClient client;
+  final Database db;
+
+  @override
+  State<PhienDangNhap> createState() => _PhienDangNhapState();
+}
+
+class _PhienDangNhapState extends State<PhienDangNhap> {
+  late final DanhMucRepository _danhMuc;
+  late final DiemRepository _diem;
+  late final SyncEngine _syncEngine;
+  StreamSubscription<bool>? _dangKyKetNoi;
+
+  @override
+  void initState() {
+    super.initState();
+    final outbox = OutboxRepository(widget.db);
+    _danhMuc = DanhMucRepository(api: widget.client, db: widget.db);
+    _diem = DiemRepository(api: widget.client, outbox: outbox);
+    _syncEngine = SyncEngine(
+      api: widget.client,
+      outbox: outbox,
+      danhMuc: _danhMuc,
+    );
+    _dangKyKetNoi = ConnectivityWatcher().thayDoi.listen((coKetNoi) {
+      if (coKetNoi) _syncEngine.chaySync();
+    });
+    // Catch up on anything queued from a previous session on startup too.
+    _syncEngine.chaySync();
+  }
+
+  @override
+  void dispose() {
+    _dangKyKetNoi?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppLifecycleSyncTrigger(
+      syncEngine: _syncEngine,
+      child: StudentsScreen(
+        danhMuc: _danhMuc,
+        diem: _diem,
+        syncEngine: _syncEngine,
+      ),
+    );
+  }
+}

--- a/mobile/lib/repositories/danh_muc_repository.dart
+++ b/mobile/lib/repositories/danh_muc_repository.dart
@@ -1,0 +1,96 @@
+import 'package:sqflite/sqflite.dart';
+
+import '../api_client.dart';
+import '../models/hoc_sinh.dart';
+import '../models/ly_do.dart';
+import '../models/qua_tang.dart';
+
+/// Caches the reference data a teacher needs (students, reasons, gifts) so
+/// the app keeps working with no connection. Strategy: try the network
+/// first - it's the freshest data, and refreshes the cache for next time -
+/// and fall back to whatever was last synced when the network call fails.
+class DanhMucRepository {
+  DanhMucRepository({required this.api, required this.db});
+  final DiemApi api;
+  final Database db;
+
+  Future<List<HocSinh>> danhSachHocSinh() async {
+    try {
+      final ds = await api.danhSachHocSinh();
+      await db.transaction((txn) async {
+        await txn.delete('hoc_sinh_cache');
+        for (final hs in ds) {
+          await txn.insert('hoc_sinh_cache', hs.toCacheRow());
+        }
+      });
+      return ds;
+    } catch (_) {
+      final rows = await db.query('hoc_sinh_cache', orderBy: 'ho_ten ASC');
+      return rows.map(HocSinh.fromCacheRow).toList();
+    }
+  }
+
+  Future<List<LyDo>> danhSachLyDo() async {
+    try {
+      final ds = await api.danhSachLyDo();
+      await db.transaction((txn) async {
+        await txn.delete('ly_do_cache');
+        for (final ld in ds) {
+          await txn.insert('ly_do_cache', ld.toCacheRow());
+        }
+      });
+      return ds;
+    } catch (_) {
+      final rows = await db.query('ly_do_cache', orderBy: 'bien_diem DESC');
+      return rows.map(LyDo.fromCacheRow).toList();
+    }
+  }
+
+  Future<List<QuaTang>> danhSachQuaTang() async {
+    try {
+      final ds = await api.danhSachQuaTang();
+      await db.transaction((txn) async {
+        await txn.delete('qua_tang_cache');
+        for (final qt in ds) {
+          await txn.insert('qua_tang_cache', qt.toCacheRow());
+        }
+      });
+      return ds;
+    } catch (_) {
+      final rows = await db.query('qua_tang_cache', orderBy: 'gia_diem ASC');
+      return rows.map(QuaTang.fromCacheRow).toList();
+    }
+  }
+
+  /// Reconciles a cached balance after the sync engine confirms an action
+  /// applied - the server's response is authoritative (it may differ from
+  /// what was assumed offline, e.g. a gift's price changed in the meantime).
+  Future<void> capNhatSoDuHocSinh(int hocSinhId, int soDuMoi) {
+    return db.update(
+      'hoc_sinh_cache',
+      {
+        'so_du_may_chu': soDuMoi,
+        'cap_nhat_luc': DateTime.now().toIso8601String(),
+      },
+      where: 'id = ?',
+      whereArgs: [hocSinhId],
+    );
+  }
+
+  /// Best-effort local decrement after a redeem syncs (the API response
+  /// doesn't echo remaining stock) - corrected for real on the next
+  /// [danhSachQuaTang] refresh. Mirrors the server's own rule (see
+  /// quy_doi_qua_tang in lib/diem_nghiep_vu.php): only decrement when stock
+  /// is a real positive count. A negative ton_kho means "unlimited" and is
+  /// never touched - `MAX(x - 1, 0)` would wrongly turn -1 into 0 (looking
+  /// out of stock) after a single redeem.
+  Future<void> giamTonKhoQuaTang(int quaTangId) {
+    return db.rawUpdate(
+      'UPDATE qua_tang_cache SET '
+      'ton_kho_may_chu = CASE WHEN ton_kho_may_chu > 0 '
+      'THEN ton_kho_may_chu - 1 ELSE ton_kho_may_chu END, '
+      'cap_nhat_luc = ? WHERE id = ?',
+      [DateTime.now().toIso8601String(), quaTangId],
+    );
+  }
+}

--- a/mobile/lib/repositories/diem_repository.dart
+++ b/mobile/lib/repositories/diem_repository.dart
@@ -1,0 +1,83 @@
+import 'package:uuid/uuid.dart';
+
+import '../api_client.dart';
+import '../loi_phan_loai.dart';
+import '../outbox/hanh_dong_cho.dart';
+import '../outbox/outbox_repository.dart';
+
+const _uuid = Uuid();
+
+enum KetQuaGhiDiem { daApDungNgay, dangCho }
+
+/// Write-side entry point for point actions. Tries the network immediately,
+/// so the common case (online) still gets synchronous success/failure
+/// feedback; only queues the action (via [OutboxRepository], to be replayed
+/// later by the sync engine) when the immediate attempt fails for a
+/// transient reason. A permanent/business failure (e.g. an inactive reason,
+/// insufficient balance) is surfaced to the caller right away instead of
+/// silently queued to fail again identically later.
+class DiemRepository {
+  DiemRepository({required this.api, required this.outbox});
+  final DiemApi api;
+  final OutboxRepository outbox;
+
+  Future<KetQuaGhiDiem> themCongDiem({
+    required int hocSinhId,
+    required int lyDoId,
+    String ghiChu = '',
+  }) async {
+    final clientActionId = _uuid.v4();
+    try {
+      await api.congDiem(
+        hocSinhId: hocSinhId,
+        lyDoId: lyDoId,
+        ghiChu: ghiChu,
+        clientActionId: clientActionId,
+      );
+      return KetQuaGhiDiem.daApDungNgay;
+    } catch (loi) {
+      if (!laLoiTamThoi(loi)) rethrow;
+      await outbox.themMoi(
+        HanhDongCho(
+          clientActionId: clientActionId,
+          loai: LoaiHanhDong.congDiem,
+          hocSinhId: hocSinhId,
+          lyDoId: lyDoId,
+          ghiChu: ghiChu,
+          taoLuc: DateTime.now().toIso8601String(),
+        ),
+      );
+      return KetQuaGhiDiem.dangCho;
+    }
+  }
+
+  Future<KetQuaGhiDiem> themDoiQua({
+    required int hocSinhId,
+    required int quaTangId,
+    String ghiChu = '',
+  }) async {
+    final clientActionId = _uuid.v4();
+    try {
+      await api.quyDoiQuaTang(
+        hocSinhId: hocSinhId,
+        quaTangId: quaTangId,
+        ghiChu: ghiChu,
+        clientActionId: clientActionId,
+      );
+      return KetQuaGhiDiem.daApDungNgay;
+    } catch (loi) {
+      if (!laLoiTamThoi(loi)) rethrow;
+      await outbox.themMoi(
+        HanhDongCho(
+          clientActionId: clientActionId,
+          loai: LoaiHanhDong.doiQua,
+          hocSinhId: hocSinhId,
+          quaTangId: quaTangId,
+          ghiChu: ghiChu,
+          taoLuc: DateTime.now().toIso8601String(),
+        ),
+      );
+      return KetQuaGhiDiem.dangCho;
+    }
+  }
+}

--- a/mobile/lib/screens/failed_actions_screen.dart
+++ b/mobile/lib/screens/failed_actions_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+
+import '../outbox/hanh_dong_cho.dart';
+import '../outbox/outbox_repository.dart';
+import '../repositories/danh_muc_repository.dart';
+import '../sync/sync_engine.dart';
+import '../utils/thong_bao_loi.dart';
+
+class _DuLieuManHinh {
+  _DuLieuManHinh(this.danhSach, this.tenTheoId);
+  final List<HanhDongCho> danhSach;
+  final Map<int, String> tenTheoId;
+}
+
+/// Lets a teacher review point actions that failed permanently (an inactive
+/// reason, insufficient balance, an out-of-stock gift, ...) - see
+/// SyncEngine's error classification. These are never auto-retried; a
+/// teacher discards them or retries manually once whatever caused the
+/// failure might have changed.
+class FailedActionsScreen extends StatefulWidget {
+  const FailedActionsScreen({
+    super.key,
+    required this.outbox,
+    required this.syncEngine,
+    required this.danhMuc,
+  });
+
+  final OutboxRepository outbox;
+  final SyncEngine syncEngine;
+  final DanhMucRepository danhMuc;
+
+  @override
+  State<FailedActionsScreen> createState() => _FailedActionsScreenState();
+}
+
+class _FailedActionsScreenState extends State<FailedActionsScreen> {
+  late Future<_DuLieuManHinh> _duLieu;
+
+  @override
+  void initState() {
+    super.initState();
+    _duLieu = _nap();
+  }
+
+  Future<_DuLieuManHinh> _nap() async {
+    final danhSach = await widget.outbox.layDanhSachLoiVinhVien();
+    final hocSinh = await widget.danhMuc.danhSachHocSinh();
+    final tenTheoId = {for (final hs in hocSinh) hs.id: hs.hoTen};
+    return _DuLieuManHinh(danhSach, tenTheoId);
+  }
+
+  void _lamMoi() => setState(() => _duLieu = _nap());
+
+  Future<void> _thuLai(int id) async {
+    await widget.outbox.datLaiChoXuLy(id);
+    await widget.syncEngine.chaySync();
+    _lamMoi();
+  }
+
+  Future<void> _xoa(int id) async {
+    await widget.outbox.xoa(id);
+    _lamMoi();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Thao tác lỗi')),
+      body: FutureBuilder<_DuLieuManHinh>(
+        future: _duLieu,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final duLieu = snap.data!;
+          if (duLieu.danhSach.isEmpty) {
+            return const Center(child: Text('Không có thao tác lỗi nào'));
+          }
+          return ListView.separated(
+            itemCount: duLieu.danhSach.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, i) {
+              final hd = duLieu.danhSach[i];
+              final ten =
+                  duLieu.tenTheoId[hd.hocSinhId] ?? 'Học sinh #${hd.hocSinhId}';
+              return ListTile(
+                title: Text(ten),
+                subtitle: Text(thongBaoLoi(hd.loiMa)),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.refresh),
+                      tooltip: 'Thử lại',
+                      onPressed: () => _thuLai(hd.id!),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Xóa',
+                      onPressed: () => _xoa(hd.id!),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/login_screen.dart
+++ b/mobile/lib/screens/login_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../api_client.dart';
+import '../db/app_database.dart';
 import '../main.dart';
-import 'students_screen.dart';
+import '../phien_dang_nhap.dart';
+import '../secure_token_storage.dart';
 
 /// Lets a teacher point the app at their DClass server and paste the API
 /// token generated from cau_hinh.php's "Tài khoản" tab (shown there as text
@@ -42,10 +44,13 @@ class _LoginScreenState extends State<LoginScreen> {
       await client.danhSachHocSinh();
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(prefsBaseUrl, baseUrl);
-      await prefs.setString(prefsToken, token);
+      await luuToken(token);
+      final db = await openAppDatabase();
       if (!mounted) return;
       Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => StudentsScreen(client: client)),
+        MaterialPageRoute(
+          builder: (_) => PhienDangNhap(client: client, db: db),
+        ),
       );
     } catch (e) {
       setState(() => _loi = 'Không kết nối được: $e');

--- a/mobile/lib/screens/redeem_gift_screen.dart
+++ b/mobile/lib/screens/redeem_gift_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import '../models/qua_tang.dart';
+
+/// Bottom sheet to pick a gift to redeem - mirrors the reason-picker sheet
+/// used by the add-points flow in students_screen.dart.
+Future<QuaTang?> chonQuaTangDeDoi(BuildContext context, List<QuaTang> ds) {
+  return showModalBottomSheet<QuaTang>(
+    context: context,
+    builder: (ctx) => SafeArea(
+      child: ListView(
+        shrinkWrap: true,
+        children: ds
+            .map(
+              (qt) => ListTile(
+                leading: const Icon(Icons.card_giftcard),
+                title: Text(qt.ten),
+                subtitle: Text('Còn ${qt.tonKho} - ${qt.giaDiem} điểm'),
+                enabled: qt.tonKho != 0,
+                onTap: () => Navigator.of(ctx).pop(qt),
+              ),
+            )
+            .toList(),
+      ),
+    ),
+  );
+}

--- a/mobile/lib/screens/students_screen.dart
+++ b/mobile/lib/screens/students_screen.dart
@@ -1,17 +1,28 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
-import '../api_client.dart';
 import '../models/hoc_sinh.dart';
 import '../models/ly_do.dart';
+import '../models/qua_tang.dart';
+import '../repositories/danh_muc_repository.dart';
+import '../repositories/diem_repository.dart';
+import '../sync/sync_engine.dart';
+import '../widgets/sync_status_badge.dart';
+import 'failed_actions_screen.dart';
+import 'redeem_gift_screen.dart';
 
 /// Student list with a quick "add points" action per row - the core
 /// in-class flow the mobile app exists for (web stays the tool for
 /// admin/reports/setup).
 class StudentsScreen extends StatefulWidget {
-  final ApiClient client;
-  const StudentsScreen({super.key, required this.client});
+  final DanhMucRepository danhMuc;
+  final DiemRepository diem;
+  final SyncEngine syncEngine;
+  const StudentsScreen({
+    super.key,
+    required this.danhMuc,
+    required this.diem,
+    required this.syncEngine,
+  });
 
   @override
   State<StudentsScreen> createState() => _StudentsScreenState();
@@ -23,23 +34,48 @@ class _StudentsScreenState extends State<StudentsScreen> {
   @override
   void initState() {
     super.initState();
-    _hocSinh = widget.client.danhSachHocSinh();
+    _hocSinh = widget.danhMuc.danhSachHocSinh();
   }
 
   Future<void> _lamMoi() async {
-    setState(() => _hocSinh = widget.client.danhSachHocSinh());
+    await widget.syncEngine.chaySync();
+    setState(() => _hocSinh = widget.danhMuc.danhSachHocSinh());
     await _hocSinh;
   }
 
-  String _taoClientActionId() {
-    final r = Random();
-    return '${DateTime.now().microsecondsSinceEpoch}-${r.nextInt(1 << 32)}';
+  Future<void> _chonHanhDong(HocSinh hs) async {
+    final hanhDong = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.add_circle_outline),
+              title: const Text('Cộng điểm...'),
+              onTap: () => Navigator.of(ctx).pop('cong_diem'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.card_giftcard),
+              title: const Text('Đổi quà...'),
+              onTap: () => Navigator.of(ctx).pop('doi_qua'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (!mounted || hanhDong == null) return;
+    if (hanhDong == 'cong_diem') {
+      await _chonLyDoVaCongDiem(hs);
+    } else {
+      await _chonQuaVaDoiDiem(hs);
+    }
   }
 
   Future<void> _chonLyDoVaCongDiem(HocSinh hs) async {
     List<LyDo> lyDoList;
     try {
-      lyDoList = await widget.client.danhSachLyDo();
+      lyDoList = await widget.danhMuc.danhSachLyDo();
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(
@@ -69,15 +105,17 @@ class _StudentsScreenState extends State<StudentsScreen> {
     );
     if (lyDo == null) return;
     try {
-      await widget.client.congDiem(
+      final ketQua = await widget.diem.themCongDiem(
         hocSinhId: hs.id,
         lyDoId: lyDo.id,
-        clientActionId: _taoClientActionId(),
       );
       if (!mounted) return;
+      final thongBao = ketQua == KetQuaGhiDiem.daApDungNgay
+          ? 'Đã cộng điểm cho ${hs.hoTen}'
+          : 'Đã ghi nhận cho ${hs.hoTen} - sẽ đồng bộ khi có mạng';
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Đã cộng điểm cho ${hs.hoTen}')));
+      ).showSnackBar(SnackBar(content: Text(thongBao)));
       await _lamMoi();
     } catch (e) {
       if (!mounted) return;
@@ -87,10 +125,67 @@ class _StudentsScreenState extends State<StudentsScreen> {
     }
   }
 
+  Future<void> _chonQuaVaDoiDiem(HocSinh hs) async {
+    List<QuaTang> quaTangList;
+    try {
+      quaTangList = await widget.danhMuc.danhSachQuaTang();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Lỗi tải quà: $e')));
+      return;
+    }
+    if (!mounted) return;
+    final quaTang = await chonQuaTangDeDoi(context, quaTangList);
+    if (quaTang == null) return;
+    try {
+      final ketQua = await widget.diem.themDoiQua(
+        hocSinhId: hs.id,
+        quaTangId: quaTang.id,
+      );
+      if (!mounted) return;
+      final thongBao = ketQua == KetQuaGhiDiem.daApDungNgay
+          ? 'Đã đổi ${quaTang.ten} cho ${hs.hoTen}'
+          : 'Đã ghi nhận cho ${hs.hoTen} - sẽ đồng bộ khi có mạng';
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(thongBao)));
+      await _lamMoi();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Lỗi: $e')));
+    }
+  }
+
+  void _moThaoTacLoi() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FailedActionsScreen(
+          outbox: widget.diem.outbox,
+          syncEngine: widget.syncEngine,
+          danhMuc: widget.danhMuc,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Học sinh')),
+      appBar: AppBar(
+        title: const Text('Học sinh'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.error_outline),
+            tooltip: 'Thao tác lỗi',
+            onPressed: _moThaoTacLoi,
+          ),
+          SyncStatusBadge(syncEngine: widget.syncEngine),
+        ],
+      ),
       body: RefreshIndicator(
         onRefresh: _lamMoi,
         child: FutureBuilder<List<HocSinh>>(
@@ -115,7 +210,7 @@ class _StudentsScreenState extends State<StudentsScreen> {
                   title: Text(hs.hoTen),
                   subtitle: Text(hs.tenLop ?? ''),
                   trailing: Text('${hs.soDu} điểm'),
-                  onTap: () => _chonLyDoVaCongDiem(hs),
+                  onTap: () => _chonHanhDong(hs),
                 );
               },
             );

--- a/mobile/lib/secure_token_storage.dart
+++ b/mobile/lib/secure_token_storage.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _khoaToken = 'api_token';
+
+const _storage = FlutterSecureStorage();
+
+/// Reads the saved Bearer token from secure storage (Keychain/Keystore).
+///
+/// The token is a single-active-credential secret equivalent to a password
+/// for a teacher's real student roster - `shared_preferences` (plain,
+/// unencrypted storage on both platforms) is the wrong place to keep it.
+/// On first read, migrates a legacy plaintext copy left over from before
+/// this file existed, then deletes it, so an existing install isn't
+/// silently logged out.
+Future<String?> docToken() async {
+  final tuAnToan = await _storage.read(key: _khoaToken);
+  if (tuAnToan != null) return tuAnToan;
+
+  final prefs = await SharedPreferences.getInstance();
+  final cu = prefs.getString(_khoaToken);
+  if (cu != null) {
+    await _storage.write(key: _khoaToken, value: cu);
+    await prefs.remove(_khoaToken);
+    return cu;
+  }
+  return null;
+}
+
+Future<void> luuToken(String token) {
+  return _storage.write(key: _khoaToken, value: token);
+}
+
+Future<void> xoaToken() {
+  return _storage.delete(key: _khoaToken);
+}

--- a/mobile/lib/sync/app_lifecycle_sync_trigger.dart
+++ b/mobile/lib/sync/app_lifecycle_sync_trigger.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+import 'sync_engine.dart';
+
+/// Triggers a sync whenever the app returns to the foreground. Wraps the
+/// whole authenticated shell (see `phien_dang_nhap.dart`) rather than being
+/// mixed into individual screens, so it fires regardless of which screen
+/// happens to be showing on resume.
+class AppLifecycleSyncTrigger extends StatefulWidget {
+  const AppLifecycleSyncTrigger({
+    super.key,
+    required this.syncEngine,
+    required this.child,
+  });
+
+  final SyncEngine syncEngine;
+  final Widget child;
+
+  @override
+  State<AppLifecycleSyncTrigger> createState() =>
+      _AppLifecycleSyncTriggerState();
+}
+
+class _AppLifecycleSyncTriggerState extends State<AppLifecycleSyncTrigger>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      widget.syncEngine.chaySync();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/mobile/lib/sync/connectivity_watcher.dart
+++ b/mobile/lib/sync/connectivity_watcher.dart
@@ -1,0 +1,22 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// Collapses connectivity_plus's per-interface result list down to the
+/// single boolean the sync engine cares about: "is there any connection at
+/// all right now".
+class ConnectivityWatcher {
+  ConnectivityWatcher() : _connectivity = Connectivity();
+  final Connectivity _connectivity;
+
+  /// Emits whenever overall connectivity changes (regained or lost).
+  Stream<bool> get thayDoi {
+    return _connectivity.onConnectivityChanged.map(_coKetNoi).distinct();
+  }
+
+  Future<bool> coKetNoiHienTai() async {
+    return _coKetNoi(await _connectivity.checkConnectivity());
+  }
+
+  bool _coKetNoi(List<ConnectivityResult> ds) {
+    return ds.any((r) => r != ConnectivityResult.none);
+  }
+}

--- a/mobile/lib/sync/sync_engine.dart
+++ b/mobile/lib/sync/sync_engine.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+
+import '../api_client.dart';
+import '../loi_phan_loai.dart';
+import '../outbox/hanh_dong_cho.dart';
+import '../outbox/outbox_repository.dart';
+import '../repositories/danh_muc_repository.dart';
+
+/// Replays the queued outbox against the server, strictly in order. The
+/// server has no notion of "client's expected prior balance" - every write
+/// recomputes from live state - so an out-of-order replay can change
+/// business outcome even though every individual call is safely retryable
+/// (e.g. a queued "redeem gift" replayed before a queued "earn points" can
+/// fail for insufficient balance, even though the original order would have
+/// succeeded). Foreground-only by design: triggered by connectivity regained
+/// ([ConnectivityWatcher]), app resume ([AppLifecycleSyncTrigger]), manual
+/// pull-to-refresh, or an explicit "sync now" action - never a background
+/// service.
+class SyncEngine extends ChangeNotifier {
+  SyncEngine({required this.api, required this.outbox, required this.danhMuc});
+
+  final DiemApi api;
+  final OutboxRepository outbox;
+  final DanhMucRepository danhMuc;
+
+  bool dangDongBo = false;
+  int soLuongChoXuLy = 0;
+  String? loiGanNhat;
+
+  Future<void>? _dangChay;
+
+  /// Runs a sync pass. Concurrent callers while one is already in flight
+  /// await that same pass rather than starting a parallel one.
+  Future<void> chaySync() {
+    final dangChay = _dangChay;
+    if (dangChay != null) return dangChay;
+    final future = _chayThuc();
+    _dangChay = future;
+    return future.whenComplete(() => _dangChay = null);
+  }
+
+  Future<void> _chayThuc() async {
+    dangDongBo = true;
+    notifyListeners();
+    try {
+      // An app kill mid-send can leave a row stuck "dang_gui" - safe to
+      // reset because the server's client_action_id idempotency guarantees
+      // a resend either double-checks harmlessly or applies fresh.
+      await outbox.quetDangGuiConLai();
+      final danhSach = await outbox.layDanhSachChoXuLy();
+      for (final hanhDong in danhSach) {
+        final tiepTuc = await _xuLyMot(hanhDong);
+        if (!tiepTuc) break;
+      }
+    } finally {
+      soLuongChoXuLy = await outbox.demSoLuongChoXuLy();
+      dangDongBo = false;
+      notifyListeners();
+    }
+  }
+
+  /// Sends one queued action. Returns whether the batch should continue to
+  /// the next item.
+  Future<bool> _xuLyMot(HanhDongCho hanhDong) async {
+    final id = hanhDong.id!;
+    await outbox.danDauDangGui(id);
+    try {
+      final Map<String, dynamic> ketQua;
+      if (hanhDong.loai == LoaiHanhDong.congDiem) {
+        ketQua = await api.congDiem(
+          hocSinhId: hanhDong.hocSinhId,
+          lyDoId: hanhDong.lyDoId!,
+          ghiChu: hanhDong.ghiChu,
+          clientActionId: hanhDong.clientActionId,
+        );
+      } else {
+        ketQua = await api.quyDoiQuaTang(
+          hocSinhId: hanhDong.hocSinhId,
+          quaTangId: hanhDong.quaTangId!,
+          ghiChu: hanhDong.ghiChu,
+          clientActionId: hanhDong.clientActionId,
+        );
+      }
+      final soDu = (ketQua['so_du'] as num?)?.toInt();
+      if (soDu != null) {
+        await danhMuc.capNhatSoDuHocSinh(hanhDong.hocSinhId, soDu);
+      }
+      if (hanhDong.loai == LoaiHanhDong.doiQua && hanhDong.quaTangId != null) {
+        await danhMuc.giamTonKhoQuaTang(hanhDong.quaTangId!);
+      }
+      await outbox.xoaSauKhiThanhCong(id);
+      loiGanNhat = null;
+      return true;
+    } catch (loi) {
+      if (laLoiTamThoi(loi)) {
+        // Order must not be skipped over here: a later item running before
+        // this unresolved one would break the replay-in-order guarantee.
+        await outbox.datLaiChoXuLy(id);
+        loiGanNhat = loi.toString();
+        return false;
+      }
+      // A failed call makes no server-side state change (the PHP either
+      // throws before any write or rolls back its transaction), so later
+      // queued items still see real, unperturbed server state - safe to
+      // skip this one and continue.
+      final maLoi = loi is ApiException ? loi.thongBao : loi.toString();
+      await outbox.danhDauLoiVinhVien(id, maLoi);
+      return true;
+    }
+  }
+}

--- a/mobile/lib/utils/thong_bao_loi.dart
+++ b/mobile/lib/utils/thong_bao_loi.dart
@@ -1,0 +1,22 @@
+/// Friendly Vietnamese message for a queued action's stored error code
+/// (`HanhDongCho.loiMa`) - mirrors the server's error strings (see
+/// `lib/diem_nghiep_vu.php`) or an `ApiClient`-synthesized `loi_http_<code>`.
+String thongBaoLoi(String? maLoi) {
+  switch (maLoi) {
+    case 'het_hang':
+      return 'Quà đã hết hàng';
+    case 'khong_du_diem':
+      return 'Học sinh không đủ điểm để đổi quà';
+    case 'ly_do_khong_hop_le':
+      return 'Lý do không còn hoạt động';
+    case 'qua_khong_hop_le':
+      return 'Quà không còn hoạt động';
+    case 'khong_du_quyen':
+      return 'Không có quyền trên học sinh này';
+    case 'thieu_thong_tin':
+      return 'Thiếu thông tin cần thiết';
+    case 'loi_http_401':
+      return 'Token không hợp lệ, vui lòng đăng nhập lại';
+  }
+  return maLoi == null ? 'Lỗi không xác định' : 'Lỗi: $maLoi';
+}

--- a/mobile/lib/widgets/sync_status_badge.dart
+++ b/mobile/lib/widgets/sync_status_badge.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../sync/connectivity_watcher.dart';
+import '../sync/sync_engine.dart';
+
+/// AppBar action showing offline/syncing/pending-count status; tapping it
+/// triggers a manual sync.
+class SyncStatusBadge extends StatefulWidget {
+  const SyncStatusBadge({super.key, required this.syncEngine});
+
+  final SyncEngine syncEngine;
+
+  @override
+  State<SyncStatusBadge> createState() => _SyncStatusBadgeState();
+}
+
+class _SyncStatusBadgeState extends State<SyncStatusBadge> {
+  final _ketNoi = ConnectivityWatcher();
+  bool _coKetNoi = true;
+  StreamSubscription<bool>? _dangKy;
+
+  @override
+  void initState() {
+    super.initState();
+    _ketNoi.coKetNoiHienTai().then((gt) {
+      if (mounted) setState(() => _coKetNoi = gt);
+    });
+    _dangKy = _ketNoi.thayDoi.listen((gt) {
+      if (mounted) setState(() => _coKetNoi = gt);
+    });
+  }
+
+  @override
+  void dispose() {
+    _dangKy?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.syncEngine,
+      builder: (context, _) {
+        if (widget.syncEngine.dangDongBo) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          );
+        }
+        final soLuong = widget.syncEngine.soLuongChoXuLy;
+        final Widget icon;
+        final String nhan;
+        if (!_coKetNoi) {
+          icon = const Icon(Icons.cloud_off);
+          nhan = 'Ngoại tuyến';
+        } else if (soLuong > 0) {
+          icon = Badge(
+            label: Text('$soLuong'),
+            child: const Icon(Icons.cloud_upload),
+          );
+          nhan = '$soLuong thao tác chưa đồng bộ - nhấn để đồng bộ ngay';
+        } else {
+          icon = const Icon(Icons.cloud_done);
+          nhan = 'Đã đồng bộ';
+        }
+        return IconButton(
+          icon: icon,
+          tooltip: nhan,
+          onPressed: () => widget.syncEngine.chaySync(),
+        );
+      },
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -22,6 +22,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^4.0.0
   sqflite_common_ffi: ^2.3.0
+  flutter_secure_storage_platform_interface: ^1.1.2
 
 flutter:
   uses-material-design: true

--- a/mobile/test/danh_muc_repository_test.dart
+++ b/mobile/test/danh_muc_repository_test.dart
@@ -1,0 +1,144 @@
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/models/hoc_sinh.dart';
+import 'package:dclass_mobile/models/ly_do.dart';
+import 'package:dclass_mobile/models/qua_tang.dart';
+import 'package:dclass_mobile/repositories/danh_muc_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'fakes/fake_diem_api.dart';
+
+void main() {
+  late FakeDiemApi api;
+  late Database db;
+  late DanhMucRepository repo;
+
+  setUp(() async {
+    api = FakeDiemApi();
+    db = await openAppDatabase(path: inMemoryDatabasePath);
+    repo = DanhMucRepository(api: api, db: db);
+  });
+
+  test('online: returns fresh data and upserts the cache', () async {
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 1,
+        ma: 'HS1',
+        hoTen: 'An',
+        lopHocId: 1,
+        tenLop: '1A',
+        soDu: 5,
+      ),
+    ];
+
+    final ds = await repo.danhSachHocSinh();
+
+    expect(ds, hasLength(1));
+    expect(ds.single.hoTen, 'An');
+
+    // Cache was upserted - the next offline call should still see it.
+    api.loiHocSinh = Exception('mat_ket_noi');
+    final tuCache = await repo.danhSachHocSinh();
+    expect(tuCache, hasLength(1));
+    expect(tuCache.single.hoTen, 'An');
+  });
+
+  test('offline: falls back to the last-synced cache', () async {
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 1,
+        ma: null,
+        hoTen: 'Binh',
+        lopHocId: null,
+        tenLop: null,
+        soDu: 10,
+      ),
+    ];
+    await repo.danhSachHocSinh(); // seeds the cache while "online"
+
+    api.loiHocSinh = Exception('mat_ket_noi');
+    final ds = await repo.danhSachHocSinh();
+
+    expect(ds, hasLength(1));
+    expect(ds.single.hoTen, 'Binh');
+    expect(ds.single.soDu, 10);
+  });
+
+  test(
+    'offline with an empty cache returns an empty list, not a throw',
+    () async {
+      api.loiHocSinh = Exception('mat_ket_noi');
+      final ds = await repo.danhSachHocSinh();
+      expect(ds, isEmpty);
+    },
+  );
+
+  test('a fresh fetch fully replaces the cache (no stale leftovers)', () async {
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 1,
+        ma: null,
+        hoTen: 'Cu',
+        lopHocId: null,
+        tenLop: null,
+        soDu: 0,
+      ),
+    ];
+    await repo.danhSachHocSinh();
+
+    api.hocSinhTraVe = [
+      HocSinh(
+        id: 2,
+        ma: null,
+        hoTen: 'Danh',
+        lopHocId: null,
+        tenLop: null,
+        soDu: 0,
+      ),
+    ];
+    await repo.danhSachHocSinh();
+
+    api.loiHocSinh = Exception('mat_ket_noi');
+    final ds = await repo.danhSachHocSinh();
+    expect(ds.map((e) => e.hoTen), ['Danh']);
+  });
+
+  test('ly do: caches and falls back the same way', () async {
+    api.lyDoTraVe = [LyDo(id: 1, tieuDe: 'Phat bieu', bienDiem: 5)];
+    await repo.danhSachLyDo();
+
+    api.loiLyDo = Exception('mat_ket_noi');
+    final ds = await repo.danhSachLyDo();
+    expect(ds.single.tieuDe, 'Phat bieu');
+  });
+
+  test('giamTonKhoQuaTang decrements a positive stock by one', () async {
+    final qt = QuaTang(id: 1, ten: 'Keo', giaDiem: 3, tonKho: 5, anhUrl: null);
+    await db.insert('qua_tang_cache', qt.toCacheRow());
+
+    await repo.giamTonKhoQuaTang(1);
+
+    final rows = await db.query('qua_tang_cache', where: 'id = 1');
+    expect(rows.single['ton_kho_may_chu'], 4);
+  });
+
+  test(
+    'giamTonKhoQuaTang leaves unlimited stock (negative) untouched',
+    () async {
+      final qt = QuaTang(
+        id: 1,
+        ten: 'Keo',
+        giaDiem: 3,
+        tonKho: -1,
+        anhUrl: null,
+      );
+      await db.insert('qua_tang_cache', qt.toCacheRow());
+
+      await repo.giamTonKhoQuaTang(1);
+
+      final rows = await db.query('qua_tang_cache', where: 'id = 1');
+      expect(rows.single['ton_kho_may_chu'], -1);
+    },
+  );
+}

--- a/mobile/test/diem_repository_test.dart
+++ b/mobile/test/diem_repository_test.dart
@@ -1,0 +1,65 @@
+import 'package:dclass_mobile/api_client.dart';
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/outbox/outbox_repository.dart';
+import 'package:dclass_mobile/repositories/diem_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'fakes/fake_diem_api.dart';
+
+void main() {
+  late FakeDiemApi api;
+  late OutboxRepository outbox;
+  late DiemRepository repo;
+
+  setUp(() async {
+    api = FakeDiemApi();
+    final db = await openAppDatabase(path: inMemoryDatabasePath);
+    outbox = OutboxRepository(db);
+    repo = DiemRepository(api: api, outbox: outbox);
+  });
+
+  test('online success: applies immediately, nothing queued', () async {
+    api.hangDoiKetQua.add({'so_du': 15});
+
+    final ketQua = await repo.themCongDiem(hocSinhId: 1, lyDoId: 2);
+
+    expect(ketQua, KetQuaGhiDiem.daApDungNgay);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+    expect(api.lenhDaGoi, hasLength(1));
+  });
+
+  test('transient failure: queues the action instead of throwing', () async {
+    api.hangDoiKetQua.add(Exception('SocketException: mat ket noi'));
+
+    final ketQua = await repo.themCongDiem(hocSinhId: 1, lyDoId: 2);
+
+    expect(ketQua, KetQuaGhiDiem.dangCho);
+    final ds = await outbox.layDanhSachChoXuLy();
+    expect(ds, hasLength(1));
+    expect(ds.single.hocSinhId, 1);
+    expect(ds.single.lyDoId, 2);
+  });
+
+  test('permanent failure: rethrows and does not queue', () async {
+    api.hangDoiKetQua.add(ApiException('het_hang'));
+
+    await expectLater(
+      () => repo.themDoiQua(hocSinhId: 1, quaTangId: 5),
+      throwsA(isA<ApiException>()),
+    );
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test(
+    'the same clientActionId used in the API call is stored on the queued row',
+    () async {
+      api.hangDoiKetQua.add(Exception('timeout'));
+      await repo.themCongDiem(hocSinhId: 1, lyDoId: 2);
+
+      final goiVoi = api.lenhDaGoi.single.split(':').last;
+      final ds = await outbox.layDanhSachChoXuLy();
+      expect(ds.single.clientActionId, goiVoi);
+    },
+  );
+}

--- a/mobile/test/fakes/fake_diem_api.dart
+++ b/mobile/test/fakes/fake_diem_api.dart
@@ -1,0 +1,81 @@
+import 'package:dclass_mobile/api_client.dart';
+import 'package:dclass_mobile/models/hoc_sinh.dart';
+import 'package:dclass_mobile/models/ly_do.dart';
+import 'package:dclass_mobile/models/qua_tang.dart';
+
+/// Hand-rolled fake for [DiemApi] - lets tests script exactly what each call
+/// returns or throws, and records call order (for asserting the sync engine
+/// replays the outbox sequentially and in order).
+class FakeDiemApi implements DiemApi {
+  List<HocSinh> hocSinhTraVe = [];
+  List<LyDo> lyDoTraVe = [];
+  List<QuaTang> quaTangTraVe = [];
+
+  /// Set to make the corresponding read throw instead of returning data -
+  /// simulates being offline.
+  Object? loiHocSinh;
+  Object? loiLyDo;
+  Object? loiQuaTang;
+
+  /// Queue of results `congDiem`/`quyDoiQuaTang` return, one per call, in
+  /// order. Each entry is either a `Map<String, dynamic>` (success payload)
+  /// or any other [Object], which is thrown as-is.
+  final List<Object> hangDoiKetQua = [];
+
+  /// `'congDiem:<clientActionId>'` / `'quyDoiQuaTang:<clientActionId>'` for
+  /// every write call made so far, in call order.
+  final List<String> lenhDaGoi = [];
+
+  @override
+  Future<List<HocSinh>> danhSachHocSinh({
+    int? lopHocId,
+    String tuKhoa = '',
+  }) async {
+    if (loiHocSinh != null) throw loiHocSinh!;
+    return hocSinhTraVe;
+  }
+
+  @override
+  Future<List<LyDo>> danhSachLyDo() async {
+    if (loiLyDo != null) throw loiLyDo!;
+    return lyDoTraVe;
+  }
+
+  @override
+  Future<List<QuaTang>> danhSachQuaTang() async {
+    if (loiQuaTang != null) throw loiQuaTang!;
+    return quaTangTraVe;
+  }
+
+  Object _layKetQuaTiepTheo(String tenLenh, String? clientActionId) {
+    lenhDaGoi.add('$tenLenh:${clientActionId ?? ''}');
+    if (hangDoiKetQua.isEmpty) {
+      throw StateError('FakeDiemApi: no scripted result left for $tenLenh');
+    }
+    return hangDoiKetQua.removeAt(0);
+  }
+
+  @override
+  Future<Map<String, dynamic>> congDiem({
+    required int hocSinhId,
+    required int lyDoId,
+    String ghiChu = '',
+    String? clientActionId,
+  }) async {
+    final ketQua = _layKetQuaTiepTheo('congDiem', clientActionId);
+    if (ketQua is Map<String, dynamic>) return ketQua;
+    throw ketQua;
+  }
+
+  @override
+  Future<Map<String, dynamic>> quyDoiQuaTang({
+    required int hocSinhId,
+    required int quaTangId,
+    String ghiChu = '',
+    String? clientActionId,
+  }) async {
+    final ketQua = _layKetQuaTiepTheo('quyDoiQuaTang', clientActionId);
+    if (ketQua is Map<String, dynamic>) return ketQua;
+    throw ketQua;
+  }
+}

--- a/mobile/test/fakes/fake_secure_storage_platform.dart
+++ b/mobile/test/fakes/fake_secure_storage_platform.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+
+/// In-memory fake for [FlutterSecureStoragePlatform], registered in widget
+/// tests the same way `SharedPreferences.setMockInitialValues({})` fakes
+/// shared_preferences - there's no bundled mock equivalent for
+/// flutter_secure_storage, so this is hand-written against the small
+/// platform-interface contract.
+class FakeSecureStoragePlatform extends FlutterSecureStoragePlatform {
+  final Map<String, String> _luuTru = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    _luuTru[key] = value;
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    return _luuTru[key];
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    return _luuTru.containsKey(key);
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    _luuTru.remove(key);
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) async {
+    return Map.of(_luuTru);
+  }
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async {
+    _luuTru.clear();
+  }
+}

--- a/mobile/test/outbox_repository_test.dart
+++ b/mobile/test/outbox_repository_test.dart
@@ -1,0 +1,112 @@
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/outbox/hanh_dong_cho.dart';
+import 'package:dclass_mobile/outbox/outbox_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+HanhDongCho _hanhDongMau({String clientActionId = 'ca-1', int hocSinhId = 1}) {
+  return HanhDongCho(
+    clientActionId: clientActionId,
+    loai: LoaiHanhDong.congDiem,
+    hocSinhId: hocSinhId,
+    lyDoId: 1,
+    taoLuc: DateTime.now().toIso8601String(),
+  );
+}
+
+void main() {
+  late OutboxRepository outbox;
+
+  setUp(() async {
+    final db = await openAppDatabase(path: inMemoryDatabasePath);
+    outbox = OutboxRepository(db);
+  });
+
+  test(
+    'layDanhSachChoXuLy returns rows in strict insertion (id) order',
+    () async {
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-2'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-3'));
+
+      final ds = await outbox.layDanhSachChoXuLy();
+
+      expect(ds.map((e) => e.clientActionId), ['ca-1', 'ca-2', 'ca-3']);
+      expect(ds.every((e) => e.trangThai == TrangThaiHanhDong.choXuLy), isTrue);
+    },
+  );
+
+  test(
+    'a permanently-failed action is excluded from layDanhSachChoXuLy',
+    () async {
+      final id1 = await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-2'));
+
+      await outbox.danhDauLoiVinhVien(id1, 'het_hang');
+
+      final choXuLy = await outbox.layDanhSachChoXuLy();
+      expect(choXuLy.map((e) => e.clientActionId), ['ca-2']);
+
+      final loi = await outbox.layDanhSachLoiVinhVien();
+      expect(loi, hasLength(1));
+      expect(loi.single.clientActionId, 'ca-1');
+      expect(loi.single.loiMa, 'het_hang');
+    },
+  );
+
+  test('quetDangGuiConLai resets leftover in-flight rows to pending', () async {
+    final id = await outbox.themMoi(_hanhDongMau());
+    await outbox.danDauDangGui(id);
+
+    // Simulate the app being killed mid-send: the row is stuck "dang_gui".
+    var ds = await outbox.layDanhSachChoXuLy();
+    expect(ds.single.trangThai, TrangThaiHanhDong.dangGui);
+
+    await outbox.quetDangGuiConLai();
+
+    ds = await outbox.layDanhSachChoXuLy();
+    expect(ds.single.trangThai, TrangThaiHanhDong.choXuLy);
+  });
+
+  test('datLaiChoXuLy resets state and increments the attempt count', () async {
+    final id = await outbox.themMoi(_hanhDongMau());
+    await outbox.danDauDangGui(id);
+
+    await outbox.datLaiChoXuLy(id);
+
+    final ds = await outbox.layDanhSachChoXuLy();
+    expect(ds.single.trangThai, TrangThaiHanhDong.choXuLy);
+    expect(ds.single.soLanThu, 1);
+  });
+
+  test(
+    'xoa removes a permanently-failed action for good (user discard)',
+    () async {
+      final id = await outbox.themMoi(_hanhDongMau());
+      await outbox.danhDauLoiVinhVien(id, 'khong_du_diem');
+
+      await outbox.xoa(id);
+
+      expect(await outbox.layDanhSachLoiVinhVien(), isEmpty);
+      expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+    },
+  );
+
+  test('xoaSauKhiThanhCong removes a completed action', () async {
+    final id = await outbox.themMoi(_hanhDongMau());
+    await outbox.xoaSauKhiThanhCong(id);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test(
+    'demSoLuongChoXuLy counts everything except permanent failures',
+    () async {
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-1'));
+      final id2 = await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-2'));
+      await outbox.themMoi(_hanhDongMau(clientActionId: 'ca-3'));
+      await outbox.danhDauLoiVinhVien(id2, 'het_hang');
+
+      expect(await outbox.demSoLuongChoXuLy(), 2);
+    },
+  );
+}

--- a/mobile/test/secure_token_storage_test.dart
+++ b/mobile/test/secure_token_storage_test.dart
@@ -1,0 +1,45 @@
+import 'package:dclass_mobile/secure_token_storage.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'fakes/fake_secure_storage_platform.dart';
+
+void main() {
+  setUp(() {
+    FlutterSecureStoragePlatform.instance = FakeSecureStoragePlatform();
+  });
+
+  test('no token saved anywhere: docToken returns null', () async {
+    SharedPreferences.setMockInitialValues({});
+    expect(await docToken(), isNull);
+  });
+
+  test('luuToken/docToken round-trip through secure storage', () async {
+    SharedPreferences.setMockInitialValues({});
+    await luuToken('token-moi');
+    expect(await docToken(), 'token-moi');
+  });
+
+  test(
+    'migrates a legacy plaintext token from shared_preferences once',
+    () async {
+      SharedPreferences.setMockInitialValues({'api_token': 'token-cu'});
+
+      final token = await docToken();
+      expect(token, 'token-cu');
+
+      // Migrated into secure storage and removed from shared_preferences.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('api_token'), isNull);
+      expect(await docToken(), 'token-cu'); // now served from secure storage
+    },
+  );
+
+  test('xoaToken removes the saved token', () async {
+    SharedPreferences.setMockInitialValues({});
+    await luuToken('token-moi');
+    await xoaToken();
+    expect(await docToken(), isNull);
+  });
+}

--- a/mobile/test/sync_engine_test.dart
+++ b/mobile/test/sync_engine_test.dart
@@ -1,0 +1,150 @@
+import 'package:dclass_mobile/api_client.dart';
+import 'package:dclass_mobile/db/app_database.dart';
+import 'package:dclass_mobile/outbox/hanh_dong_cho.dart';
+import 'package:dclass_mobile/outbox/outbox_repository.dart';
+import 'package:dclass_mobile/repositories/danh_muc_repository.dart';
+import 'package:dclass_mobile/sync/sync_engine.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'fakes/fake_diem_api.dart';
+
+HanhDongCho _hanhDongCongDiem({
+  required String clientActionId,
+  int hocSinhId = 1,
+}) {
+  return HanhDongCho(
+    clientActionId: clientActionId,
+    loai: LoaiHanhDong.congDiem,
+    hocSinhId: hocSinhId,
+    lyDoId: 1,
+    taoLuc: DateTime.now().toIso8601String(),
+  );
+}
+
+void main() {
+  late FakeDiemApi api;
+  late Database db;
+  late OutboxRepository outbox;
+  late DanhMucRepository danhMuc;
+  late SyncEngine engine;
+
+  setUp(() async {
+    api = FakeDiemApi();
+    db = await openAppDatabase(path: inMemoryDatabasePath);
+    outbox = OutboxRepository(db);
+    danhMuc = DanhMucRepository(api: api, db: db);
+    engine = SyncEngine(api: api, outbox: outbox, danhMuc: danhMuc);
+  });
+
+  test('replays queued actions sequentially, in insertion order', () async {
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-2'));
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-3'));
+    api.hangDoiKetQua.addAll([
+      {'so_du': 1},
+      {'so_du': 2},
+      {'so_du': 3},
+    ]);
+
+    await engine.chaySync();
+
+    expect(api.lenhDaGoi, ['congDiem:ca-1', 'congDiem:ca-2', 'congDiem:ca-3']);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test('success reconciles the cached balance from the response', () async {
+    await db.insert('hoc_sinh_cache', {
+      'id': 1,
+      'ho_ten': 'An',
+      'so_du_may_chu': 0,
+    });
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    api.hangDoiKetQua.add({'so_du': 42});
+
+    await engine.chaySync();
+
+    final rows = await db.query('hoc_sinh_cache', where: 'id = 1');
+    expect(rows.single['so_du_may_chu'], 42);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test(
+    'a permanent failure is marked loi_vinh_vien and the batch continues',
+    () async {
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-2'));
+      api.hangDoiKetQua.addAll([
+        ApiException('het_hang'),
+        {'so_du': 9},
+      ]);
+
+      await engine.chaySync();
+
+      expect(api.lenhDaGoi, ['congDiem:ca-1', 'congDiem:ca-2']);
+      final loi = await outbox.layDanhSachLoiVinhVien();
+      expect(loi.single.clientActionId, 'ca-1');
+      expect(loi.single.loiMa, 'het_hang');
+      expect(await outbox.layDanhSachChoXuLy(), isEmpty); // ca-2 applied
+    },
+  );
+
+  test(
+    'a transient failure re-queues the item and halts the rest of the batch',
+    () async {
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+      await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-2'));
+      api.hangDoiKetQua.add(Exception('SocketException: mat ket noi'));
+      // Only one scripted result: proves ca-2 is never attempted.
+
+      await engine.chaySync();
+
+      expect(api.lenhDaGoi, ['congDiem:ca-1']); // ca-2 not attempted
+      final choXuLy = await outbox.layDanhSachChoXuLy();
+      expect(choXuLy.map((e) => e.clientActionId), ['ca-1', 'ca-2']);
+      expect(choXuLy.first.trangThai, TrangThaiHanhDong.choXuLy);
+      expect(choXuLy.first.soLanThu, 1);
+      expect(choXuLy.last.soLanThu, 0); // untouched
+    },
+  );
+
+  test('a retried action reuses the same client_action_id', () async {
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    api.hangDoiKetQua.add(Exception('timeout'));
+    await engine.chaySync(); // fails transiently, re-queued
+
+    api.hangDoiKetQua.add({'so_du': 5});
+    await engine.chaySync(); // retried
+
+    expect(api.lenhDaGoi, ['congDiem:ca-1', 'congDiem:ca-1']);
+    expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+  });
+
+  test('concurrent chaySync calls collapse into a single pass', () async {
+    await outbox.themMoi(_hanhDongCongDiem(clientActionId: 'ca-1'));
+    api.hangDoiKetQua.add({'so_du': 1});
+
+    final f1 = engine.chaySync();
+    final f2 = engine.chaySync();
+    await Future.wait([f1, f2]);
+
+    expect(api.lenhDaGoi, hasLength(1));
+  });
+
+  test(
+    'a leftover dang_gui row is swept back to pending on the next run',
+    () async {
+      final id = await outbox.themMoi(
+        _hanhDongCongDiem(clientActionId: 'ca-1'),
+      );
+      await outbox.danDauDangGui(id); // simulate an app kill mid-send
+
+      api.hangDoiKetQua.add({'so_du': 7});
+      await engine.chaySync();
+
+      expect(api.lenhDaGoi, ['congDiem:ca-1']);
+      expect(await outbox.layDanhSachChoXuLy(), isEmpty);
+    },
+  );
+}

--- a/mobile/test/thong_bao_loi_test.dart
+++ b/mobile/test/thong_bao_loi_test.dart
@@ -1,0 +1,19 @@
+import 'package:dclass_mobile/utils/thong_bao_loi.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('maps known server error codes to Vietnamese messages', () {
+    expect(thongBaoLoi('het_hang'), contains('hết hàng'));
+    expect(thongBaoLoi('khong_du_diem'), contains('không đủ điểm'));
+    expect(thongBaoLoi('ly_do_khong_hop_le'), contains('Lý do'));
+    expect(thongBaoLoi('loi_http_401'), contains('đăng nhập lại'));
+  });
+
+  test('falls back to a generic message for an unrecognized code', () {
+    expect(thongBaoLoi('loi_la'), 'Lỗi: loi_la');
+  });
+
+  test('handles a null error code', () {
+    expect(thongBaoLoi(null), 'Lỗi không xác định');
+  });
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,11 +1,15 @@
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dclass_mobile/main.dart';
 
+import 'fakes/fake_secure_storage_platform.dart';
+
 void main() {
   testWidgets('shows the login screen when no token is saved', (tester) async {
     SharedPreferences.setMockInitialValues({});
+    FlutterSecureStoragePlatform.instance = FakeSecureStoragePlatform();
     await tester.pumpWidget(const DClassApp());
     await tester.pump();
     expect(find.text('Kết nối DClass'), findsOneWidget);


### PR DESCRIPTION
## Summary
Phases 1-5 of the offline+sync plan (#85-#89) merged into their intermediate stacked feature branches as designed, but never reached `main` - #84 (Phase 0, the base of the stack) got merged into `main` moments before the others cascaded down into it, so `main` ended up with only Phase 0. Stacked PRs need merging top-of-stack-first for the cascade to work; merging bottom-up instead (as happened here) strands everything above the first merge.

This PR brings in exactly the stranded content:
- **Phase 1** — `DanhMucRepository`: offline-viewable students/reasons/gifts cache
- **Phase 2** — outbox + `DiemRepository`: queue point actions when offline
- **Phase 3** — `SyncEngine`: sequential, order-preserving replay + connectivity/resume/pull-to-refresh triggers
- **Phase 4** — redeem-gift flow, sync status badge, failed-actions review screen
- **Phase 5** — Bearer token moved to `flutter_secure_storage`

Phase 0 is untouched by this diff - confirmed identical between `main` and the stack tip before staging (`app_database.dart`/`api_client.dart` show zero diff). Includes the two bugfixes found while building this (`openAppDatabase` `singleInstance` for test isolation; `giamTonKhoQuaTang` no longer zeroing out unlimited gift stock) - already part of the stacked branches' history, not new here.

## Test plan
- [ ] `CI Flutter (mobile)` passes (same test suite already green on the stacked branches - `dart format`, `flutter analyze`, `flutter test` covering outbox/sync-engine/repository/secure-storage logic against real in-memory SQLite and fakes)
- [ ] Manual end-to-end once merged: queue actions offline, confirm they sync automatically on reconnect with no duplicates in `api/diem.php?hanh_dong=lich_su`

🤖 Generated with [Claude Code](https://claude.com/claude-code)