### PR TITLE
backend: add PRAGMA busy_timeout/WAL to reduce SQLite lock errors

### DIFF
--- a/config/db.php
+++ b/config/db.php
@@ -49,6 +49,10 @@ try {
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
   $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
   $pdo->exec("PRAGMA foreign_keys = ON");
+  // Web (session) và mobile (token, #81) có thể ghi đồng thời vào cùng 1 file SQLite;
+  // busy_timeout khiến SQLite tự đợi thay vì ném "database is locked" ngay khi tranh chấp khoá ngắn hạn.
+  $pdo->exec("PRAGMA busy_timeout = 5000");
+  $pdo->exec("PRAGMA journal_mode = WAL");
 } catch (Exception $e) { http_response_code(500); echo 'Loi ket noi CSDL'; exit; }
 
 require __DIR__ . '/migration_nghiep_vu.php';


### PR DESCRIPTION
## Summary
Closes #104.

`config/db.php` opened SQLite with no `busy_timeout`/WAL. Since mobile got Bearer-token write access (#81), web (session) and mobile can write concurrently to the same file; without this, a lock conflict throws `SQLSTATE[HY000]: database is locked` immediately instead of the writer waiting a moment and retrying.

- `PRAGMA busy_timeout = 5000` - wait up to 5s on a lock instead of failing instantly.
- `PRAGMA journal_mode = WAL` - allows a reader and a writer to proceed concurrently.

## Test plan
- [x] `composer test` (27/27 PHPUnit tests pass)