### PR TITLE
web: quick-scoring UX pass - colors, shortcuts, random caller, confetti

### DIFF
--- a/public/dang_nhap.php
+++ b/public/dang_nhap.php
@@ -73,7 +73,7 @@ if (isset($_SESSION['giao_vien_id']) || thu_cookie_ghi_nho($pdo)) { header('Loca
           <button id="btn" class="btn btn-primary w-100 btn-lg shadow-sm">Đăng nhập</button>
           <div id="msg" class="small text-danger mt-2"></div>
           <div class="text-center mt-3">
-            <button type="button" id="btn_toggle_dang_ky" class="btn btn-link btn-sm p-0">Chưa có tài khoản? Đăng ký ngay</button>
+            <button type="button" id="btn_toggle_dang_ky" class="btn btn-outline-primary btn-sm">Chưa có tài khoản? Đăng ký ngay</button>
           </div>
         </div>
       </div>
@@ -115,7 +115,7 @@ if (isset($_SESSION['giao_vien_id']) || thu_cookie_ghi_nho($pdo)) { header('Loca
           <button id="dk_btn" class="btn btn-primary w-100 btn-lg shadow-sm">Đăng ký</button>
           <div id="dk_msg" class="small text-danger mt-2"></div>
           <div class="text-center mt-3">
-            <button type="button" id="btn_toggle_dang_nhap" class="btn btn-link btn-sm p-0">Đã có tài khoản? Đăng nhập</button>
+            <button type="button" id="btn_toggle_dang_nhap" class="btn btn-outline-primary btn-sm">Đã có tài khoản? Đăng nhập</button>
           </div>
         </div>
       </div>

--- a/public/lich_su.php
+++ b/public/lich_su.php
@@ -21,7 +21,8 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
         <div class="col-md-2 col-sm-6">
           <select id="loc_loai" class="form-select form-select-sm">
             <option value="">Loại: Tất cả</option>
-            <option value="CONG_DIEM">Cộng điểm</option>
+            <option value="CONG_DIEM_POS">Cộng điểm</option>
+            <option value="CONG_DIEM_NEG">Trừ điểm</option>
             <option value="DOI_DIEM">Đổi điểm</option>
             <option value="HOAN_TAC">Hoàn tác</option>
           </select>
@@ -80,10 +81,12 @@ function tenLoai(loai){
     default: return loai;
   }
 }
-function loaiBadge(loai){
+function loaiBadge(loai, bienDiem){
   const base = 'badge rounded-pill';
   switch(String(loai||'')){
-    case 'CONG_DIEM': return `<span class="${base} bg-success-subtle text-success border border-success-subtle">Cộng điểm</span>`;
+    case 'CONG_DIEM': return (Number(bienDiem)||0) < 0
+      ? `<span class="${base} bg-danger-subtle text-danger border border-danger-subtle">Trừ điểm</span>`
+      : `<span class="${base} bg-success-subtle text-success border border-success-subtle">Cộng điểm</span>`;
     case 'DOI_DIEM': return `<span class="${base} bg-warning-subtle text-warning border border-warning-subtle">Đổi điểm</span>`;
     case 'HOAN_TAC': return `<span class="${base} bg-secondary-subtle text-secondary border border-secondary-subtle">Hoàn tác</span>`;
     default: return `<span class="${base} bg-light text-body-secondary">${tenLoai(loai)}</span>`;
@@ -123,7 +126,9 @@ function locVaSapXep(){
   const tuTs = tu ? Date.parse(tu+'T00:00:00') : null;
   const denTs = den ? Date.parse(den+'T23:59:59') : null;
   duLieuLoc = (duLieu||[]).filter(row=>{
-    if (loai && row.loai !== loai) return false;
+    if (loai==='CONG_DIEM_POS' && !(row.loai==='CONG_DIEM' && (Number(row.bien_diem)||0) >= 0)) return false;
+    if (loai==='CONG_DIEM_NEG' && !(row.loai==='CONG_DIEM' && (Number(row.bien_diem)||0) < 0)) return false;
+    if (loai && loai!=='CONG_DIEM_POS' && loai!=='CONG_DIEM_NEG' && row.loai !== loai) return false;
     const ts = parseDate(row.tao_luc);
     if (tuTs !== null && ts && ts < tuTs) return false;
     if (denTs !== null && ts && ts > denTs) return false;
@@ -154,7 +159,7 @@ function veTrang(){
   tb.innerHTML='';
   duLieuLoc.slice(start,end).forEach(row=>{
     const tr=document.createElement('tr');
-    const loaiHtml = loaiBadge(row.loai);
+    const loaiHtml = loaiBadge(row.loai, row.bien_diem);
     const deltaHtml = formatSignedHtml(row.bien_diem);
     const balanceHtml = `<span class="fw-semibold">${row.so_du_sau}</span>`;
     tr.innerHTML=`<td data-label="Thời gian">${dinDangDateTime(row.tao_luc)}</td><td data-label="Học sinh">${row.ho_ten}</td><td data-label="Loại">${loaiHtml}</td><td data-label="Thay đổi">${deltaHtml}</td><td data-label="Số dư">${balanceHtml}</td><td data-label="Ghi chú">${row.ghi_chu||''}</td>`;

--- a/public/trang_chinh.php
+++ b/public/trang_chinh.php
@@ -26,8 +26,11 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
 <div class="container py-3 safe-bottom">
   <div class="row g-3">
     <div class="col-md-6"><div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
-      <h5 class="ribbon-title-modern">Danh sách học sinh</h5>
-      <input id="tu_khoa" class="form-control" placeholder="Tìm theo tên hoặc mã học sinh">
+      <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+        <h5 class="ribbon-title-modern mb-0">Danh sách học sinh</h5>
+        <button id="btn_goi_ten" type="button" class="btn btn-outline-primary btn-sm" title="Gọi tên ngẫu nhiên">🎲 Gọi tên</button>
+      </div>
+      <input id="tu_khoa" class="form-control mt-2" placeholder="Tìm theo tên hoặc mã học sinh">
       <div id="ds_hs" class="list-group mt-2" style="max-height:300px;overflow:auto"></div>
     </div></div></div>
     <div class="col-md-6"><div class="card shadow-sm" data-aos="fade-up"><div class="card-body">
@@ -75,6 +78,23 @@ if (!empty($_SESSION['phai_doi_mat_khau'])) { header('Location: cau_hinh.php'); 
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body" id="qua_modal_body"></div>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="goiTenModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="ribbon-title-modern modal-title">Gọi tên ngẫu nhiên</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center py-4">
+        <div id="goiTenName" class="fs-2 fw-bold text-primary">—</div>
+      </div>
+      <div class="modal-footer justify-content-center">
+        <button id="goiTenQuay" type="button" class="btn btn-outline-primary">Quay lại</button>
+        <button id="goiTenChon" type="button" class="btn btn-success d-none">Chọn học sinh này</button>
+      </div>
     </div>
   </div>
 </div><script>
@@ -181,10 +201,19 @@ function renderLyDo(){
   const kw = norm(document.getElementById('ly_do_loc')?.value||'');
   (lyDoData||[])
     .filter(ld => !kw || norm(ld.tieu_de).includes(kw))
-    .forEach(ld => {
+    .slice()
+    .sort((a,b) => Number(b.bien_diem) - Number(a.bien_diem))
+    .forEach((ld, idx) => {
       const b=document.createElement('button');
-      b.className='btn btn-outline-primary';
+      b.className = 'btn ' + (Number(ld.bien_diem)<0 ? 'btn-outline-danger' : 'btn-outline-success');
       b.textContent = `${ld.tieu_de} (${ld.bien_diem>0?'+':''}${ld.bien_diem})`;
+      if(idx<12){
+        b.title = `Phím tắt: F${idx+1}`;
+        const kbd=document.createElement('kbd');
+        kbd.className='ms-2 small';
+        kbd.textContent=`F${idx+1}`;
+        b.appendChild(kbd);
+      }
       b.onclick = async()=>{
         if(!hsHienTai){
           showToast('Hãy chọn học sinh.','warning');
@@ -195,13 +224,107 @@ function renderLyDo(){
         if(jj.ok){
           hsHienTai.so_du=jj.du_lieu.so_du;
           hienThongTin(); napHocSinh(); napLichSu(); if(typeof napThongKe==='function') napThongKe();
+          if(Number(ld.bien_diem) > 0){ hieuUngCongDiem(); }
         } else {
           showToast(jj.thong_bao||'L\u1ed7i','danger');
         }
       };
       box.appendChild(b);
     });
-}async function napLyDo(){
+}
+
+// Hi\u1ec7u \u1ee9ng khi c\u1ed9ng \u0111i\u1ec3m: confetti to\u00e0n m\u00e0n h\u00ecnh + ti\u1ebfng v\u1ed7 tay t\u1ed5ng h\u1ee3p (kh\u00f4ng c\u1ea7n file \u00e2m thanh ngo\u00e0i,
+// tr\u00e1nh ph\u1ee5 thu\u1ed9c m\u1ea1ng/b\u1ea3n quy\u1ec1n - d\u00f9ng noise \u0111\u00e3 l\u1ecdc qua Web Audio API \u0111\u1ec3 gi\u1ea3 l\u1eadp ti\u1ebfng v\u1ed7 tay).
+let _confettiOverlayDangChay=null;
+function hieuUngCongDiem(){
+  hieuUngConfetti();
+  phatAmThanhVoTay();
+}
+function hieuUngConfetti(){
+  if(_confettiOverlayDangChay){ _confettiOverlayDangChay(); }
+  const overlay=document.createElement('canvas');
+  overlay.style.cssText='position:fixed;inset:0;width:100vw;height:100vh;z-index:2000;cursor:pointer;';
+  overlay.title='Nh\u1ea5n \u0111\u1ec3 b\u1ecf qua hi\u1ec7u \u1ee9ng';
+  document.body.appendChild(overlay);
+  const ctx=overlay.getContext('2d');
+  function resize(){ overlay.width=window.innerWidth; overlay.height=window.innerHeight; }
+  resize();
+  const mauSac=['#ff595e','#ffca3a','#8ac926','#1982c4','#6a4c93','#ff924c'];
+  const hat=Array.from({length:140}, () => ({
+    x: Math.random()*overlay.width,
+    y: -20 - Math.random()*overlay.height*0.5,
+    vx: (Math.random()-0.5)*3,
+    vy: 2+Math.random()*3,
+    size: 4+Math.random()*5,
+    mau: mauSac[Math.floor(Math.random()*mauSac.length)],
+    goc: Math.random()*Math.PI*2,
+    vGoc: (Math.random()-0.5)*0.3
+  }));
+  let dangChay=true;
+  const batDauLuc=performance.now();
+  const thoiLuong=2600;
+  function dungLai(){
+    if(!dangChay) return;
+    dangChay=false;
+    window.removeEventListener('resize', resize);
+    overlay.removeEventListener('click', dungLai);
+    overlay.remove();
+    if(_confettiOverlayDangChay===dungLai) _confettiOverlayDangChay=null;
+  }
+  _confettiOverlayDangChay=dungLai;
+  overlay.addEventListener('click', dungLai);
+  window.addEventListener('resize', resize);
+  function ve(now){
+    if(!dangChay) return;
+    ctx.clearRect(0,0,overlay.width,overlay.height);
+    hat.forEach(h=>{
+      h.x+=h.vx; h.y+=h.vy; h.vy+=0.02; h.goc+=h.vGoc;
+      ctx.save();
+      ctx.translate(h.x,h.y);
+      ctx.rotate(h.goc);
+      ctx.fillStyle=h.mau;
+      ctx.fillRect(-h.size/2,-h.size/2,h.size,h.size*0.6);
+      ctx.restore();
+    });
+    if(now-batDauLuc > thoiLuong){ dungLai(); return; }
+    requestAnimationFrame(ve);
+  }
+  requestAnimationFrame(ve);
+}
+function phatAmThanhVoTay(){
+  try{
+    const AC = window.AudioContext || window.webkitAudioContext;
+    if(!AC) return;
+    const actx = new AC();
+    const now = actx.currentTime;
+    const master = actx.createGain();
+    master.gain.value = 0.35;
+    master.connect(actx.destination);
+    function taoTiengVo(thoiDiem, doDai, amLuong){
+      const bufferSize = Math.floor(actx.sampleRate*doDai);
+      const buffer = actx.createBuffer(1, bufferSize, actx.sampleRate);
+      const data = buffer.getChannelData(0);
+      for(let i=0;i<bufferSize;i++){ data[i] = (Math.random()*2-1) * Math.pow(1-i/bufferSize, 2); }
+      const nguon = actx.createBufferSource();
+      nguon.buffer = buffer;
+      const loc = actx.createBiquadFilter();
+      loc.type='bandpass';
+      loc.frequency.value = 1800 + Math.random()*1200;
+      loc.Q.value = 0.7;
+      const gain = actx.createGain();
+      gain.gain.value = amLuong;
+      nguon.connect(loc); loc.connect(gain); gain.connect(master);
+      nguon.start(thoiDiem);
+      nguon.stop(thoiDiem+doDai);
+    }
+    for(let i=0;i<40;i++){
+      const t = now + Math.random()*1.8;
+      taoTiengVo(t, 0.05+Math.random()*0.05, 0.15+Math.random()*0.2);
+    }
+    setTimeout(()=>{ try{ actx.close(); }catch(_e){} }, 2500);
+  } catch(_e) { /* Web Audio kh\u00f4ng kh\u1ea3 d\u1ee5ng - b\u1ecf qua \u00e2m thanh, v\u1eabn gi\u1eef hi\u1ec7u \u1ee9ng confetti */ }
+}
+async function napLyDo(){
   const r=await fetch('../api/ly_do.php');
   const j=await r.json();
   if(!j.ok){ lyDoData=[]; renderLyDo(); return; }
@@ -284,15 +407,17 @@ function renderLichSu(){
   lsPage = Math.min(Math.max(1, lsPage), totalPages);
   const start = (lsPage-1)*lsPageSize; const rows = lsData.slice(start, start+lsPageSize);
   rows.forEach(row=>{
+    const delta = Number(row.bien_diem)||0;
     const loaiHtml = (() => {
       switch(String(row.loai||'')){
-        case 'CONG_DIEM': return '<span class="badge bg-success-subtle text-success border border-success-subtle">Cộng điểm</span>';
+        case 'CONG_DIEM': return delta<0
+          ? '<span class="badge bg-danger-subtle text-danger border border-danger-subtle">Trừ điểm</span>'
+          : '<span class="badge bg-success-subtle text-success border border-success-subtle">Cộng điểm</span>';
         case 'DOI_DIEM': return '<span class="badge bg-warning-subtle text-warning border border-warning-subtle">Đổi điểm</span>';
         case 'HOAN_TAC': return '<span class="badge bg-secondary-subtle text-secondary border border-secondary-subtle">Hoàn tác</span>';
         default: return `<span class="badge bg-light text-body-secondary">${tenLoai(row.loai)}</span>`;
       }
     })();
-    const delta = Number(row.bien_diem)||0;
     const deltaHtml = `<span class="fw-semibold ${delta>0?'text-success':'text-danger'}">${delta>0?'+':''}${delta}</span>`;
     const soDu = Number(row.so_du_sau)||0;
     const soDuHtml = `<span class="fw-semibold">${new Intl.NumberFormat('vi-VN').format(soDu)}</span>`;
@@ -354,6 +479,66 @@ document.getElementById('dang_xuat').onclick=async()=>{ await fetch('../api/dang
 if(document.getElementById('ly_do_loc')) document.getElementById('ly_do_loc').oninput = renderLyDo;
 document.getElementById('ls_prev').onclick=()=>{ lsPage=Math.max(1, lsPage-1); renderLichSu(); };
 document.getElementById('ls_next').onclick=()=>{ lsPage=lsPage+1; renderLichSu(); };
+
+// Gọi tên ngẫu nhiên (quay số) dựa trên toàn bộ danh sách học sinh, không phụ thuộc ô tìm kiếm
+(function initGoiTen(){
+  const btnMo=document.getElementById('btn_goi_ten');
+  const modalEl=document.getElementById('goiTenModal');
+  const nameEl=document.getElementById('goiTenName');
+  const btnQuay=document.getElementById('goiTenQuay');
+  const btnChon=document.getElementById('goiTenChon');
+  if(!btnMo||!modalEl||!nameEl||!btnQuay||!btnChon) return;
+  let ds=[];
+  let picked=null;
+  function quay(){
+    if(!ds.length) return;
+    btnQuay.disabled=true;
+    btnChon.classList.add('d-none');
+    picked=null;
+    const totalTicks=20+Math.floor(Math.random()*8);
+    let tick=0;
+    (function step(){
+      const s=ds[Math.floor(Math.random()*ds.length)];
+      nameEl.textContent=s.ho_ten;
+      tick++;
+      if(tick<totalTicks){
+        const progress=tick/totalTicks;
+        const delay=60+Math.round(200*progress*progress);
+        setTimeout(step, delay);
+      } else {
+        picked=ds[Math.floor(Math.random()*ds.length)];
+        nameEl.textContent=picked.ho_ten;
+        btnQuay.disabled=false;
+        btnChon.classList.remove('d-none');
+      }
+    })();
+  }
+  btnMo.onclick=async()=>{
+    const r=await fetch('../api/hoc_sinh.php');
+    const j=await r.json();
+    ds=(j.ok && Array.isArray(j.du_lieu))?j.du_lieu:[];
+    if(!ds.length){ showToast('Chưa có học sinh nào.','warning'); return; }
+    new bootstrap.Modal(modalEl).show();
+    quay();
+  };
+  btnQuay.onclick=quay;
+  btnChon.onclick=()=>{
+    if(picked){ chonHS(picked); }
+    const inst=bootstrap.Modal.getInstance(modalEl);
+    if(inst) inst.hide();
+  };
+})();
+
+// Phím tắt F1..F12 cho các nút lý do (chấm điểm nhanh không cần rời tay khỏi bàn phím)
+document.addEventListener('keydown', ev => {
+  if(ev.ctrlKey || ev.altKey || ev.metaKey) return;
+  const m = /^F([1-9]|1[0-2])$/.exec(ev.key);
+  if(!m) return;
+  const box=document.getElementById('ds_ly_do'); if(!box) return;
+  const idx = Number(m[1]) - 1;
+  const btn = box.children[idx];
+  if(btn){ ev.preventDefault(); btn.click(); }
+});
 
 // Hiển thị thông tin học sinh: thêm avatar, giới tính, ngày sinh
 function hienThongTinDep(){


### PR DESCRIPTION
## Summary
Closes #66, #67, #68, #71, #57, #25, #70.

- **#66** (`trang_chinh.php`): reason buttons color by sign (`btn-outline-success`/`btn-outline-danger`) instead of a uniform blue, so + vs - reads at a glance.
- **#67** (`lich_su.php`, `trang_chinh.php`): the "Loại" badge now shows "Trừ điểm" (not "Cộng điểm") when a `CONG_DIEM` row's `bien_diem` is negative - the same transaction type covers both reward and penalty reasons via `ly_do.bien_diem`'s sign, so the raw `loai` alone was misleading. Split `lich_su.php`'s type filter into `CONG_DIEM_POS`/`CONG_DIEM_NEG` so filtering stays consistent with the badge.
- **#68**: `trang_chinh.php`'s "Lịch sử gần đây" table already existed from an earlier commit - this PR just carries the #67 badge fix into it.
- **#71**: reasons sort "ruler"-style by point value descending (+3 +2 +1 -1 -2 -3) instead of insertion order.
- **#57**: new "🎲 Gọi tên" button spins through the loaded roster and lets the teacher pick the landed student for scoring.
- **#25**: F1-F12 shortcuts trigger the reason buttons in their (now ruler-sorted) order; each button shows its bound key.
- **#70**: awarding *positive* points triggers full-screen confetti + a synthesized (Web Audio, no external audio asset - keeps the app's "all assets local" convention and sidesteps licensing) applause sound, click-to-skip early; deductions don't trigger it.
- Also fixed `dang_nhap.php`'s "Đăng ký ngay"/"Đăng nhập" toggle buttons - they were plain `btn-link` and picked up the site's global dashed-pill `.btn` style as a stray unstyled box; now proper `btn-outline-primary` pills matching the rest of the UI.

## Test plan
- [x] Manually verified in-browser: button colors, badge text/color for both +/- CONG_DIEM rows, ruler sort order, F1-F6 shortcuts firing the right reason, gọi tên spin-and-select flow, confetti trigger only on positive adds + click-to-dismiss, login page button styling.
- [x] `php -l` on all three changed files.